### PR TITLE
allow renaming of datasets

### DIFF
--- a/web/src/common/api.service.js
+++ b/web/src/common/api.service.js
@@ -73,6 +73,10 @@ export const CSVService = {
     return ApiService.put(`csv/${slug}/imputation`, methods);
   },
 
+  setMetaData(slug, metaData) {
+    return ApiService.put(`csv/${slug}/metadata`, metaData);
+  },
+
   updateLabel(csvSlug, changes) {
     return ApiService.put(`csv/${csvSlug}/batch/label`, { changes });
   },

--- a/web/src/components/EditDatasetDialog.vue
+++ b/web/src/components/EditDatasetDialog.vue
@@ -1,0 +1,52 @@
+<script>
+import Vue from 'vue';
+
+export default Vue.extend({
+  props: {
+    dataset: {
+      required: true,
+      type: Object,
+    },
+  },
+  data() {
+    return {
+      label: this.dataset.label,
+      description: this.dataset.meta.description || '',
+    };
+  },
+  watch: {
+    dataset(newValue) {
+      this.label = newValue.label;
+      this.description = newValue.meta.description || '';
+    },
+  },
+  methods: {
+    cancel() {
+      this.$emit('submit', null);
+    },
+    submit() {
+      this.$emit('submit', {
+        label: this.label,
+        description: this.description,
+      });
+    },
+  },
+});
+</script>
+<template lang="pug">
+v-dialog(value="true", max-width="300", persistent)
+  v-card
+    v-card-title.headline Edit Data Source "{{dataset.label}}"
+
+    v-card-text
+      v-text-field(label="Name", v-model="label", required)
+      v-textarea(label="Description", v-model="description")
+
+    v-card-actions
+      v-spacer
+      v-btn(@click="cancel()") Cancel
+      v-btn(@click="submit()") Save
+</template>
+<style lang="scss" scoped>
+
+</style>

--- a/web/src/components/Pretreatment.vue
+++ b/web/src/components/Pretreatment.vue
@@ -59,7 +59,7 @@ v-layout.pretreatment-component(row, fill-height)
             @click="navigate(dataset)")
           template(v-slot:activator)
             v-list-tile.file-name
-              v-list-tile-title.title {{ dataset.name }}
+              v-list-tile-title.title {{ dataset.label }}
               v-list-tile-action(v-if="dataset.validation.length")
                 v-icon.pr-1(color="warning") {{ $vuetify.icons.warning }}
               v-list-tile-action(v-else)

--- a/web/src/store/actions.type.js
+++ b/web/src/store/actions.type.js
@@ -5,3 +5,4 @@ export const MUTEX_TRANSFORM_TABLE = 'mutex_transform_table';
 export const UPLOAD_CSV = 'upload_csv';
 export const UPLOAD_EXCEL = 'upload_excel';
 export const CHANGE_IMPUTATION_OPTIONS = 'change_imputation_options';
+export const EDIT_META_DATA = 'edit_meta_data';

--- a/web/src/store/index.js
+++ b/web/src/store/index.js
@@ -15,6 +15,7 @@ import {
   UPLOAD_CSV,
   UPLOAD_EXCEL,
   CHANGE_IMPUTATION_OPTIONS,
+  EDIT_META_DATA,
 } from './actions.type';
 
 import {
@@ -119,7 +120,9 @@ const mutations = {
       _source: data,
       id,
       name,
+      label: data.meta.label || name, // label is either the name or part of the meta data
       size,
+      meta: data.meta,
       ready: true,
       width: sourcerows[0].length, // TODO: get from server
       height: sourcerows.length, // TODO: get from server
@@ -315,6 +318,13 @@ const actions = {
   async [CHANGE_IMPUTATION_OPTIONS]({ commit }, { dataset_id, options }) {
     commit(SET_LOADING, true);
     await CSVService.setImputation(dataset_id, options);
+    await load_dataset({ commit }, { dataset_id });
+    commit(SET_LOADING, false);
+  },
+
+  async [EDIT_META_DATA]({ commit }, { dataset_id, metaData }) {
+    commit(SET_LOADING, true);
+    await CSVService.setMetaData(dataset_id, metaData);
     await load_dataset({ commit }, { dataset_id });
     commit(SET_LOADING, false);
   },


### PR DESCRIPTION
closes #197

allows the user to rename a dataset and add a description to it. It stores the custom data in the `.meta` field of the DB. In addition, on the client side the `dataset.label` attribute points the the preferred label to show. The `dataset.name` is still the original file name

![image](https://user-images.githubusercontent.com/4129778/65153633-19d4bd00-d9f8-11e9-8744-97be7a756509.png)

![image](https://user-images.githubusercontent.com/4129778/65153647-222cf800-d9f8-11e9-8ee6-4a77b8652913.png)
