### PR TITLE
Change docker build to install R deps in the base image

### DIFF
--- a/devops/Dockerfile
+++ b/devops/Dockerfile
@@ -1,6 +1,6 @@
 FROM viime/opencpu-base
 
 ADD viime /viime
-RUN R -e 'library(devtools); library(roxygen2); setwd("/viime"); devtools::update_packages(devtools::dev_package_deps()$package, dependencies=NA, quiet=TRUE, upgrade="never"); document(); setwd("/");install("viime", dependencies=NA, quiet=TRUE, upgrade="never")'
+RUN R -e 'library(devtools); library(roxygen2); install("viime", dependencies=NA, quiet=TRUE, upgrade="never")'
 
 CMD service cron start && /usr/lib/rstudio-server/bin/rserver && apachectl -DFOREGROUND

--- a/devops/Dockerfile.base
+++ b/devops/Dockerfile.base
@@ -32,3 +32,6 @@ RUN R -e 'install.packages("devtools"); library(devtools)'
 RUN R -e 'library(devtools); devtools::install_github("klutometis/roxygen")'
 RUN R -e 'BiocManager::install("impute", version = "3.9")'
 RUN R -e 'install.packages("missForest")'
+
+ADD viime /viime
+RUN R -e 'setwd("/viime"); devtools::update_packages(devtools::dev_package_deps()$package, dependencies=NA, upgrade="never");' && rm -fr /viime


### PR DESCRIPTION
@sgratzl I pushed the update you added to the base image so that the rebuild doesn't take so long.  I think it will be relatively rare that we need to change the dependency list for the R package.