### PR TITLE
Inject transformation options into GET /csv/<id>

### DIFF
--- a/tests/test_csv_file_api.py
+++ b/tests/test_csv_file_api.py
@@ -158,6 +158,25 @@ def test_set_imputation_options(client, csv_file):
     assert resp.json == {'imputation_mnar': 'half-minimum', 'imputation_mcar': 'knn'}
 
 
+def test_set_transformation_options(client, csv_file):
+    resp = client.post(
+        url_for('csv.save_validated_csv_file', csv_id=csv_file.id)
+    )
+    assert resp.status_code == 201
+
+    resp = client.put(
+        url_for('csv.set_transformation_method', csv_id=csv_file.id),
+        json={'method': 'log10'}
+    )
+    assert resp.status_code == 200
+
+    resp = client.get(
+        url_for('csv.get_csv_file', csv_id=csv_file.id)
+    )
+    assert resp.status_code == 200
+    assert resp.json['transformation'] == 'log10'
+
+
 def test_merge_files(client):
     csv_file_schema = CSVFileSchema()
     csv_file1 = csv_file_schema.load({

--- a/viime/models.py
+++ b/viime/models.py
@@ -751,5 +751,6 @@ class ValidatedMetaboliteTableSchema(BaseSchema):
     @post_dump
     def serialize_tables(self, data):
         for attr in ['measurements', 'measurement_metadata', 'sample_metadata', 'groups']:
-            data[attr] = data[attr].to_csv()
+            if attr in data:
+                data[attr] = data[attr].to_csv()
         return data


### PR DESCRIPTION
This fixes a backwards compatibility issue from #167 where the transformation, normalization, and scaling options are not returned with `GET /csv/<id>`.  This implementation is a little ham handed, so I'll probably go back and refactor a few things when there are less PR's out.