### PR TITLE
Add validation errors for rows/column containing NaN's

### DIFF
--- a/web/src/utils/constants.js
+++ b/web/src/utils/constants.js
@@ -157,6 +157,16 @@ const validationMeta = {
     clickable: false,
     multi: false,
   },
+  'non-numeric-column': {
+    description: 'A column contains non-numeric metabolite data',
+    clickable: true,
+    multi: true,
+  },
+  'non-numeric-row': {
+    description: 'A row contains non-numeric metabolite data',
+    clickable: true,
+    multi: true,
+  },
 };
 const wilcoxon_zero_methods = [
   {


### PR DESCRIPTION
This promotes data rows/columns containing over 95% NaN's (or non-numeric values) to a validation error rather than a warning.  I'm not sure how the imputation code handles this case, but clearly it indicates a problem that should block further processing.

(The 95% value is arbitrary, maybe something lower or higher is more appropriate.  I mostly wanted to handle cases where a column is actually categorical metadata.)