### PR TITLE
export svg to pngs

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@girder/components": "v3.0.0-alpha.3",
     "@mdi/font": "^3.5.95",
+    "@openfonts/barlow-condensed_all": "^0.1.1",
     "@sentry/browser": "^5.0.7",
     "@sentry/integrations": "^5.0.7",
     "axios": "^0.18.0",

--- a/web/src/components/vis/BoxPlotTile.vue
+++ b/web/src/components/vis/BoxPlotTile.vue
@@ -44,7 +44,7 @@ export default {
 </script>
 
 <template lang="pug">
-vis-tile(title="Boxplot Plot", :loading="false")
+vis-tile(title="Boxplot Plot", :loading="false", svg-download)
   template(#default="wrapper")
     boxplot-plot(
         v-if="dataset.ready",

--- a/web/src/components/vis/LoadingsPlotTile.vue
+++ b/web/src/components/vis/LoadingsPlotTile.vue
@@ -50,7 +50,7 @@ export default {
 </script>
 
 <template lang="pug">
-vis-tile(v-if="plot", title="PCA Loadings Plot", :loading="plot.loading")
+vis-tile(v-if="plot", title="PCA Loadings Plot", :loading="plot.loading", svg-download)
   template(#default="wrapper")
     loadings-plot(
         :width="width * wrapper.scale",

--- a/web/src/components/vis/ScorePlotTile.vue
+++ b/web/src/components/vis/ScorePlotTile.vue
@@ -70,7 +70,7 @@ export default {
 </script>
 
 <template lang="pug">
-vis-tile(v-if="plot", title="PCA Score Plot", :loading="plot.loading")
+vis-tile(v-if="plot", title="PCA Score Plot", :loading="plot.loading", svg-download)
   template(#default="wrapper")
     score-plot(
         v-if="plot && dataset.ready",

--- a/web/src/components/vis/ScreePlotTile.vue
+++ b/web/src/components/vis/ScreePlotTile.vue
@@ -42,7 +42,7 @@ export default {
 </script>
 
 <template lang="pug">
-vis-tile(v-if="plot", title="PCA Scree Plot", :loading="plot.loading")
+vis-tile(v-if="plot", title="PCA Scree Plot", :loading="plot.loading", svg-download)
   template(#default="wrapper")
     scree-plot(
         :width="width * wrapper.scale",

--- a/web/src/components/vis/VisTile.vue
+++ b/web/src/components/vis/VisTile.vue
@@ -1,5 +1,6 @@
 <script>
 import { format } from 'd3-format';
+import { downloadSVG } from '../../utils/exporter';
 
 export default {
   props: {
@@ -8,6 +9,10 @@ export default {
       default: '',
     },
     loading: {
+      default: false,
+      type: Boolean,
+    },
+    svgDownload: {
       default: false,
       type: Boolean,
     },
@@ -43,6 +48,12 @@ export default {
     setScaleIndex(value) {
       this.scaleIndex = Math.max(Math.min(Number.parseInt(value, 10), this.scales.length - 1), 0);
     },
+    downloadSVG() {
+      const svg = this.$el.querySelector('svg');
+      if (svg) {
+        downloadSVG(svg, this.title);
+      }
+    },
   },
 };
 </script>
@@ -61,6 +72,8 @@ v-flex(shrink=1, :class="scaleClass")
         v-btn(@click="setScaleIndex(scaleIndex + 1)",
             :disabled="scaleIndex === scales.length - 1", icon)
           v-icon {{ $vuetify.icons.magnifyPlus }}
+        v-btn(v-if="svgDownload", @click="downloadSVG", icon)
+          v-icon {{ $vuetify.icons.save }}
         slot(name="controls")
     v-progress-linear.ma-0.progress(v-if="loading", indeterminate, height=4)
     v-card.bottom-rounded(flat)

--- a/web/src/utils/exporter.js
+++ b/web/src/utils/exporter.js
@@ -1,0 +1,74 @@
+
+export function svg2png(svgElement, options = {}) {
+  const findStyles = options.styles !== false;
+  const returnSvg = options.return === 'svg';
+
+  // based on http://bl.ocks.org/biovisualize/8187844
+  const copy = svgElement.cloneNode(true);
+  // proper bg
+  copy.style.backgroundColor = 'white';
+  // inject font
+  copy.style.fontFamily = 'Barlow Condensed, sans-serif';
+  copy.insertAdjacentHTML('afterbegin', `<style>
+  @import url("https://fonts.googleapis.com/css?family=Barlow+Condensed");
+  </style>`);
+
+  // find related style sheets
+  const scopedAttr = Array.from(copy.getAttributeNames()).find(d => d.startsWith('data-v-'));
+  if (findStyles && scopedAttr) {
+    const key = `[${scopedAttr}]`;
+    const rules = [];
+    Array.from(document.styleSheets).forEach((sheet) => {
+      if (sheet instanceof CSSStyleSheet) {
+        try {
+          Array.from(sheet.cssRules).forEach((rule) => {
+            if (rule.cssText.includes(key)) {
+              rules.push(rule.cssText);
+            }
+          });
+        } catch {
+          // ignore
+        }
+      }
+    });
+    copy.insertAdjacentHTML('afterbegin', `<style>${rules.join('\n')}</style>`);
+  }
+
+  const svgString = new XMLSerializer().serializeToString(copy);
+  const svg = new Blob([svgString], { type: 'image/svg+xml;charset=utf-8' });
+  const svgUrl = URL.createObjectURL(svg);
+
+  if (returnSvg) {
+    return Promise.resolve(svgUrl);
+  }
+
+  const canvas = document.createElement('canvas');
+
+  const bb = svgElement.getBoundingClientRect();
+  canvas.width = bb.width;
+  canvas.height = bb.height;
+  const ctx = canvas.getContext('2d');
+  const img = new Image(canvas.width, canvas.height);
+
+  return new Promise((resolve) => {
+    img.onload = () => {
+      ctx.drawImage(img, 0, 0);
+      URL.revokeObjectURL(svgUrl);
+      const png = canvas.toDataURL('image/png');
+      resolve(png);
+    };
+    img.src = svgUrl;
+  });
+}
+
+export async function downloadSVG(svgElement, title = 'Image') {
+  const url = await svg2png(svgElement);
+  const a = document.createElement('a');
+  a.href = url;
+  a.style.position = 'absolute';
+  a.style.left = '-10000px';
+  a.style.top = '-10000px';
+  a.download = `${title}.png`;
+  document.body.appendChild(a);
+  a.click();
+}

--- a/web/src/utils/exporter.js
+++ b/web/src/utils/exporter.js
@@ -1,3 +1,6 @@
+// eslint-disable-next-line import/no-webpack-loader-syntax
+import font from '!url-loader?limit=undefined!@openfonts/barlow-condensed_all/files/barlow-condensed-all-400.woff2';
+
 
 export function svg2png(svgElement, options = {}) {
   const findStyles = options.styles !== false;
@@ -10,7 +13,17 @@ export function svg2png(svgElement, options = {}) {
   // inject font
   copy.style.fontFamily = 'Barlow Condensed, sans-serif';
   copy.insertAdjacentHTML('afterbegin', `<style>
-  @import url("https://fonts.googleapis.com/css?family=Barlow+Condensed");
+    /* barlow-condensed-400normal - all */
+    @font-face {
+      font-family: 'Barlow Condensed';
+      font-style: normal;
+      font-display: swap;
+      font-weight: 400;
+      src:
+        local('Barlow Condensed Regular'),
+        local('BarlowCondensed-Regular'),
+        url('${font}') format('woff2')
+    }
   </style>`);
 
   // find related style sheets

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -770,6 +770,11 @@
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz#2b5a3ab3f918cca48a8c754c08168e3f03eba61b"
 
+"@openfonts/barlow-condensed_all@^0.1.1":
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/@openfonts/barlow-condensed_all/-/barlow-condensed_all-0.1.1.tgz#e31e86274da623d3e80b686eb768e28a7bc9e1a1"
+  integrity sha512-7Ojnu2xVMN8tjI2wwEVuG4xs7x8qmWmBgMk8OeU9JxLgz+rxR7TaiVuuCtmWIwZzBUvGUhkFmve6S4PEC6ThZg==
+
 "@sentry/browser@^5.0.7":
   version "5.0.7"
   resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-5.0.7.tgz#50932313e5949d086c5537663390fe7d84588edd"


### PR DESCRIPTION
closes #270 

e.g:

![PCA Score Plot](https://user-images.githubusercontent.com/4129778/65904977-a6369680-e38d-11e9-9614-e84e94c93c0f.png)

Notes
 * the generated SVG file should contain all CSS rules that it is affected by
 * However, the *external* font isn't used due to security restrictions by the browser. It is part of the SVG but included externally (there is no other way)