### PR TITLE
Reduce "loud" animation.

### DIFF
--- a/web/src/components/vis/AnovaTableTile.vue
+++ b/web/src/components/vis/AnovaTableTile.vue
@@ -36,7 +36,7 @@ vis-tile-large(v-if="plot", title="Anova Table", :loading="plot.loading", expand
     v-card.mx-3(flat)
       v-card-actions
         v-layout(column)
-          v-slider.minCorrelation(v-model="threshold", label="0", thumb-label,
+          v-slider.my-1.minCorrelation(v-model="threshold", label="0", thumb-label,
               hide-details, min="0", max="0.1", step="0.001")
   anova-table(:data="plot.data", :threshold="threshold")
 </template>

--- a/web/src/components/vis/CorrelationTile.vue
+++ b/web/src/components/vis/CorrelationTile.vue
@@ -64,7 +64,7 @@ vis-tile-large.correlation(v-if="plot", title="Correlation Network", :loading="p
     v-card.mx-3(flat)
       v-card-actions
         v-layout(column)
-          v-slider.minCorrelation(:value="min_correlation", label="0", thumb-label,
+          v-slider.my-1.minCorrelation(:value="min_correlation", label="0", thumb-label,
               hide-details, min="0", max="1", step="0.01",
               @change="changePlotArgs({min_correlation: $event})")
 
@@ -73,8 +73,8 @@ vis-tile-large.correlation(v-if="plot", title="Correlation Network", :loading="p
     v-card.mx-3(flat)
       v-card-actions
         v-layout(column)
-          v-switch(v-model="showLabels", label="Node Labels", hide-details)
-          v-text-field(v-model="linkDistance", label="Link Distance",
+          v-switch.my-1(v-model="showLabels", label="Node Labels", hide-details)
+          v-text-field.my-1(v-model="linkDistance", label="Link Distance",
               hide-details, min="0", step="10", type="number")
 
   template(#default)

--- a/web/src/components/vis/ForceDirectedGraph.vue
+++ b/web/src/components/vis/ForceDirectedGraph.vue
@@ -120,7 +120,7 @@ export default {
       this.simulation.force('collide').radius(this.radius);
       this.simulation.alpha(1).restart();
       this.simulation.tick(250);
-      for(let i = 0; i < 50; i += 1) {
+      for (let i = 0; i < 50; i += 1) {
         this.simulation.tick();
         const simNodes = this.simulation.nodes();
         const domain = extent(simNodes);
@@ -137,7 +137,8 @@ export default {
           .attr('y2', d => yScale(d.target.y));
         edges.select('text')
           .attr('transform', d => `translate(${xScale((d.source.x + d.target.x) / 2)},${yScale((d.source.y + d.target.y) / 2)})`);
-        await new Promise((resolve) => window.setTimeout(resolve, 20));
+        /* eslint-disable-next-line no-await-in-loop */
+        await new Promise(resolve => window.setTimeout(resolve, 20));
       }
     },
     onResize() {

--- a/web/src/components/vis/ForceDirectedGraph.vue
+++ b/web/src/components/vis/ForceDirectedGraph.vue
@@ -91,7 +91,7 @@ export default {
       f.force('link', forceLink().id(d => d.id).strength(d => d.value));
       return f;
     },
-    update() {
+    async update() {
       this.simulation.stop();
       const svg = select(this.$refs.svg);
       svg.attr('width', this.width).attr('height', this.height);
@@ -118,9 +118,10 @@ export default {
       this.simulation.force('link').distance(this.linkDistance).links(localEdges);
       this.simulation.force('center').x(this.width / 2).y(this.height / 2);
       this.simulation.force('collide').radius(this.radius);
-
-
-      this.simulation.on('tick', () => {
+      this.simulation.alpha(1).restart();
+      this.simulation.tick(250);
+      for(let i = 0; i < 50; i += 1) {
+        this.simulation.tick();
         const simNodes = this.simulation.nodes();
         const domain = extent(simNodes);
         const xScale = scaleLinear().domain([domain.xMin, domain.xMax])
@@ -136,10 +137,8 @@ export default {
           .attr('y2', d => yScale(d.target.y));
         edges.select('text')
           .attr('transform', d => `translate(${xScale((d.source.x + d.target.x) / 2)},${yScale((d.source.y + d.target.y) / 2)})`);
-      });
-
-
-      this.simulation.alpha(1).restart();
+        await new Promise((resolve) => window.setTimeout(resolve, 20));
+      }
     },
     onResize() {
       const bb = this.$el.getBoundingClientRect();
@@ -161,10 +160,10 @@ export default {
 <style scoped>
 .main {
   position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
+  top: 20px;
+  left: 20px;
+  right: 20px;
+  bottom: 20px;
   display: flex;
 }
 

--- a/web/src/components/vis/WilcoxonPlotTile.vue
+++ b/web/src/components/vis/WilcoxonPlotTile.vue
@@ -36,7 +36,7 @@ vis-tile-large(v-if="plot", title="Wilcoxon Test", :loading="plot.loading", expa
     v-card.mx-3(flat)
       v-card-actions
         v-layout(column)
-          v-slider.minCorrelation(v-model="threshold", label="0", thumb-label,
+          v-slider.my-1.minCorrelation(v-model="threshold", label="0", thumb-label,
               hide-details, min="0", max="0.1", step="0.001")
   wilcoxon-plot(:data="plot.data", :threshold="threshold")
 </template>


### PR DESCRIPTION
This pr:

* Changes some margins for vertical symmetry of controls
* adds padding to the correlation network page
* Removes most of the animation from the correlation network.

On that last point, the correlation network animation looked good under some conditions, but most of the time it was very overstimulating (for me).  I don't think the animation adds anything to a scientist's ability to interpret the network, so I changed it to run the first 250 ticks silently, then play the last 50 quickly.

The result is that the network kinda "falls" into its final place when you change controls rather than starting over from scratch.

I think this is an improvement because the user no longer has to wait for an animation to complete to make sense of the graph.

You should probably just look at the branch yourself to see the change, but here's a screenshot
![Screenshot from 2019-10-02 10-23-44](https://user-images.githubusercontent.com/4214172/66052524-ba4dd580-e4fe-11e9-8d05-47c12afabc24.png)

Caveat: I'm not a vis person.  I'd like feedback from those who are.