### PR TITLE
clean/multiblock integration

### DIFF
--- a/devops/viime/R/merge.R
+++ b/devops/viime/R/merge.R
@@ -46,39 +46,15 @@ compute_clean_pca <- function(prefix, measurements) {
   MS.scores.variance
 }
 
-#' multi_block_pca_merge
+#' compute_multi_block
 #'
 #' @export
-multi_block_pca_merge <- function(...) {
-  #--------------#
-  ## Multiblock ##
-  #--------------#
-  tables <- list(...)
-  
-  prepare_table <- function(t) {
-    MS_metab = read.csv(t, row.names=1)
-    #First matrix
-    MS.svd <- svd(MS_metab) #Perform Singular Value Decomposition
-    a_1 <- 1/(MS.svd$d[1]^2) #calculate the weight, it is the inverse of the first squared singular value
-    Z1 <- MS_metab*a_1 #multiply the entire matrix by the weight
-    
-    Z1
-  }
-  
-  mb = NULL
-  for(t in tables) {
-    z = prepare_table(t)
-    if(is.null(mb)) {
-      mb = z
-    } else {
-      mb = merge(mb, z, by='row.names')
-      rownames(mb) = mb$Row.names
-      mb = mb[-1]
-    }
-  }
-  
-  # Multiblock PCA
-  MB.PCA <- prcomp(mb, center=TRUE, scale=TRUE)
-  
-  MB.PCA$x
+compute_multi_block <- function(prefix, measurements) {
+  MS_metab = read.csv(measurements, row.names=1)
+  #First matrix
+  MS.svd <- svd(MS_metab) #Perform Singular Value Decomposition
+  a_1 <- 1/(MS.svd$d[1]^2) #calculate the weight, it is the inverse of the first squared singular value
+  Z1 <- MS_metab*a_1 #multiply the entire matrix by the weight
+
+  Z1
 }

--- a/devops/viime/R/merge.R
+++ b/devops/viime/R/merge.R
@@ -53,7 +53,7 @@ multi_block_pca_merge <- function(...) {
   #--------------#
   ## Multiblock ##
   #--------------#
-  tables <- c(...)
+  tables <- list(...)
   
   prepare_table <- function(t) {
     MS_metab = read.csv(t, row.names=1)
@@ -65,14 +65,20 @@ multi_block_pca_merge <- function(...) {
     Z1
   }
   
-  mb = prepare_table(tables[1])
-  for(t in tables[-1]) {
+  mb = NULL
+  for(t in tables) {
     z = prepare_table(t)
-    mb = merge(mb, z, by='row.names')
+    if(is.null(mb)) {
+      mb = z
+    } else {
+      mb = merge(mb, z, by='row.names')
+      rownames(mb) = mb$Row.names
+      mb = mb[-1]
+    }
   }
   
   # Multiblock PCA
   MB.PCA <- prcomp(mb, center=TRUE, scale=TRUE)
-
+  
   MB.PCA$x
 }

--- a/devops/viime/R/merge.R
+++ b/devops/viime/R/merge.R
@@ -45,3 +45,34 @@ compute_clean_pca <- function(prefix, measurements) {
 
   MS.scores.variance
 }
+
+#' multi_block_pca_merge
+#'
+#' @export
+multi_block_pca_merge <- function(...) {
+  #--------------#
+  ## Multiblock ##
+  #--------------#
+  tables <- c(...)
+  
+  prepare_table <- function(t) {
+    MS_metab = read.csv(t, row.names=1)
+    #First matrix
+    MS.svd <- svd(MS_metab) #Perform Singular Value Decomposition
+    a_1 <- 1/(MS.svd$d[1]^2) #calculate the weight, it is the inverse of the first squared singular value
+    Z1 <- MS_metab*a_1 #multiply the entire matrix by the weight
+    
+    Z1
+  }
+  
+  mb = prepare_table(tables[1])
+  for(t in tables[-1]) {
+    z = prepare_table(t)
+    mb = merge(mb, z, by='row.names')
+  }
+  
+  # Multiblock PCA
+  MB.PCA <- prcomp(mb, center=TRUE, scale=TRUE)
+
+  MB.PCA$x
+}

--- a/devops/viime/R/merge.R
+++ b/devops/viime/R/merge.R
@@ -2,46 +2,46 @@
 #' compute_clean_pca
 #'
 #' @export
-compute_clean_pca <- function(prefix, MS_metab) {
-  # MS_metab = read.csv(measurements, row.names=1)
-  
+compute_clean_pca <- function(prefix, measurements) {
+  MS_metab = read.csv(measurements, row.names=1)
+
   ###
   #PCA for MS
   ###
   #Perform pca
   # also omit constant PCs
   MS.pca <- prcomp(MS_metab, center = TRUE, tol = 0) #,scale. = TRUE #Center takes the mean of the column to all the values in the column
-  
+
   #Saving the scores
   MS.pca.scores <- MS.pca$x
   #head(MS.pca.scores)
-  
+
   #getting the standard deviations of the principal components (the square roots of the eigenvalues)
   MS.pca.sd <- MS.pca$sdev
-  
+
   # also omit constant PCs
   MS.pca.sd = MS.pca.sd[MS.pca.sd > 0]
-  
+
   #getting the eigenvalues
   MS.eig <- (MS.pca.sd)^2
-  
+
   #transform the eigenvalues in Variances in percentage (0-1)
   MS.variance <- MS.eig/sum(MS.eig)
-  
+
   #standardize scores=Scores divided by stdv
   MS.std.scores <- MS.pca.scores %*% diag(1 / MS.pca.sd)
-  
+
   #Multiply standardize scores by percentages
   MS.scores.variance <- as.matrix(MS.std.scores) %*% diag(MS.variance)
   #head(MS.scores.variance)  ###This should be the matrix to concatenate
-  
+
   #Change matrix to dataset
   MS.scores.variance <- as.data.frame(MS.scores.variance)
   MS.PC.names <- c(paste0(prefix, ".PC", 1:ncol(MS.scores.variance)))
   colnames(MS.scores.variance) <- MS.PC.names
-  
+
   #Add patient ID
   rownames(MS.scores.variance) <- rownames(MS_metab)
-  
+
   MS.scores.variance
 }

--- a/devops/viime/R/merge.R
+++ b/devops/viime/R/merge.R
@@ -9,7 +9,8 @@ compute_clean_pca <- function(prefix, MS_metab) {
   #PCA for MS
   ###
   #Perform pca
-  MS.pca <- prcomp(MS_metab, center = TRUE) #,scale. = TRUE #Center takes the mean of the column to all the values in the column
+  # also omit constant PCs
+  MS.pca <- prcomp(MS_metab, center = TRUE, tol = 0) #,scale. = TRUE #Center takes the mean of the column to all the values in the column
   
   #Saving the scores
   MS.pca.scores <- MS.pca$x
@@ -18,8 +19,11 @@ compute_clean_pca <- function(prefix, MS_metab) {
   #getting the standard deviations of the principal components (the square roots of the eigenvalues)
   MS.pca.sd <- MS.pca$sdev
   
+  # also omit constant PCs
+  MS.pca.sd = MS.pca.sd[MS.pca.sd > 0]
+  
   #getting the eigenvalues
-  MS.eig <- (MS.pca$sdev)^2
+  MS.eig <- (MS.pca.sd)^2
   
   #transform the eigenvalues in Variances in percentage (0-1)
   MS.variance <- MS.eig/sum(MS.eig)

--- a/devops/viime/R/merge.R
+++ b/devops/viime/R/merge.R
@@ -1,0 +1,43 @@
+
+#' compute_clean_pca
+#'
+#' @export
+compute_clean_pca <- function(prefix, MS_metab) {
+  # MS_metab = read.csv(measurements, row.names=1)
+  
+  ###
+  #PCA for MS
+  ###
+  #Perform pca
+  MS.pca <- prcomp(MS_metab, center = TRUE) #,scale. = TRUE #Center takes the mean of the column to all the values in the column
+  
+  #Saving the scores
+  MS.pca.scores <- MS.pca$x
+  #head(MS.pca.scores)
+  
+  #getting the standard deviations of the principal components (the square roots of the eigenvalues)
+  MS.pca.sd <- MS.pca$sdev
+  
+  #getting the eigenvalues
+  MS.eig <- (MS.pca$sdev)^2
+  
+  #transform the eigenvalues in Variances in percentage (0-1)
+  MS.variance <- MS.eig/sum(MS.eig)
+  
+  #standardize scores=Scores divided by stdv
+  MS.std.scores <- MS.pca.scores %*% diag(1 / MS.pca.sd)
+  
+  #Multiply standardize scores by percentages
+  MS.scores.variance <- as.matrix(MS.std.scores) %*% diag(MS.variance)
+  #head(MS.scores.variance)  ###This should be the matrix to concatenate
+  
+  #Change matrix to dataset
+  MS.scores.variance <- as.data.frame(MS.scores.variance)
+  MS.PC.names <- c(paste0(prefix, ".PC", 1:ncol(MS.scores.variance)))
+  colnames(MS.scores.variance) <- MS.PC.names
+  
+  #Add patient ID
+  rownames(MS.scores.variance) <- rownames(MS_metab)
+  
+  MS.scores.variance
+}

--- a/viime/models.py
+++ b/viime/models.py
@@ -242,6 +242,7 @@ class CSVFile(db.Model):
         groups = self.groups
         if groups is None or groups.empty:
             self.group_levels = []
+            return
         levels = sorted([str(v) for v in groups.iloc[:, 0].unique()])
         # d3 scheme category 10
         colors = ['#1f77b4', '#ff7f0e', '#2ca02c', '#d62728', '#9467bd', '#8c564b', '#e377c2',

--- a/viime/table_merge.py
+++ b/viime/table_merge.py
@@ -102,7 +102,7 @@ def clean_pca_merge(validated_tables: List[ValidatedMetaboliteTable]):
 def multi_block_merge(validated_tables: List[ValidatedMetaboliteTable]):
     files: OrderedDict[str, str] = OrderedDict()
     for index, table in enumerate(validated_tables):
-        files['table%d'] = table.measurements.to_csv().encode()
+        files['table%d' % index] = table.measurements.to_csv().encode()
 
     combined = opencpu_request('multi_block_pca_merge', files)
 

--- a/web/src/components/NewMerge.vue
+++ b/web/src/components/NewMerge.vue
@@ -6,6 +6,10 @@ export const mergeMethods = [
     value: 'simple',
     label: 'Simple',
   },
+  {
+    value: 'clean',
+    label: 'Clean PCA',
+  },
 ];
 
 export default {

--- a/web/src/components/NewMerge.vue
+++ b/web/src/components/NewMerge.vue
@@ -10,6 +10,10 @@ export const mergeMethods = [
     value: 'clean',
     label: 'Clean PCA',
   },
+  {
+    value: 'multi_block',
+    label: 'Multiblock PCA',
+  },
 ];
 
 export default {


### PR DESCRIPTION
closes #344 and #345 

based on the original R scripts. 

notes
 * rebuild R container
 * clean: in the end the script generates a normalized PCA of each matrix and then does an inner join to combine them (`merge(...)`). Thus, I reuse the existing simple method but transform the measurements before
 * multi block: here a new combined measurement pca table is generated