### PR TITLE
Fix loadings plots to show correct data

### DIFF
--- a/viime/views.py
+++ b/viime/views.py
@@ -1,7 +1,6 @@
 from functools import wraps
 from io import BytesIO
 import json
-import math
 from pathlib import PurePath
 from typing import Callable, cast, Dict, List, Optional
 

--- a/viime/views.py
+++ b/viime/views.py
@@ -707,38 +707,14 @@ def get_pca_plot(validated_table):
 
 
 def _get_loadings_data(validated_table):
-    def mean(x):
-        return sum(x) / len(x)
-
-    def sq(x):
-        return x * x
-
-    def cor(xs, ys):
-        if xs.equals(ys):
-            return 1.0
-
-        x_mean = mean(xs)
-        y_mean = mean(ys)
-
-        x_stddev = math.sqrt(sum(map(lambda x: sq(x - x_mean), xs)))
-        y_stddev = math.sqrt(sum(map(lambda y: sq(y - y_mean), ys)))
-
-        if x_stddev == 0 or y_stddev == 0:
-            return 0.0
-
-        prod_sum = sum(map(lambda x, y: (x - x_mean) * (y - y_mean), xs, ys))
-        return prod_sum / (x_stddev * y_stddev)
-
     table = validated_table.measurements
     pca_data = _get_pca_data(validated_table)
+    loadings = pca_data['rotation']
 
-    # Transpose the PCA values.
-    pca_data = [list(x) for x in zip(*pca_data['x'])]
-
-    # Compute correlations between each metabolite and both PC1 and PC2.
+    # Extract the correlations between each metabolite and all PCs.
     return [{'col': k,
-             'cor': [cor(v, pc) for pc in pca_data]}
-            for (k, v) in table.items()]
+             'loadings': loadings[i]}
+            for i, k in enumerate(table)]
 
 
 @csv_bp.route('/csv/<uuid:csv_id>/plot/loadings', methods=['GET'])

--- a/web/src/components/vis/LoadingsPlot.vue
+++ b/web/src/components/vis/LoadingsPlot.vue
@@ -45,7 +45,7 @@ export default {
       required: true,
       validator: prop => !prop
           || (typeof prop === 'object'
-          && prop.every(val => ['col', 'cor'].every(key => key in val))),
+          && prop.every(val => ['col', 'loadings'].every(key => key in val))),
     },
     pcX: {
       default: 1,
@@ -152,7 +152,7 @@ export default {
             tooltip.transition()
               .duration(duration)
               .style('opacity', 0.9);
-            tooltip.html(`<b>${d.col}</b><br>(${coordFormat(d.cor[pcX - 1])}, ${coordFormat(d.cor[pcY - 1])})`)
+            tooltip.html(`<b>${d.col}</b><br>(${coordFormat(d.loadings[pcX - 1])}, ${coordFormat(d.loadings[pcY - 1])})`)
               .style('left', `${event.clientX + 15}px`)
               .style('top', `${event.pageY - 30}px`);
           })
@@ -169,8 +169,8 @@ export default {
         .transition()
         .duration(this.fadeInDuration)
         .attr('r', radius)
-        .attr('cx', d => this.scaleX(d.cor[pcX - 1]))
-        .attr('cy', d => this.scaleY(d.cor[pcY - 1]));
+        .attr('cx', d => this.scaleX(d.loadings[pcX - 1]))
+        .attr('cy', d => this.scaleY(d.loadings[pcY - 1]));
     },
   },
 };


### PR DESCRIPTION
It turns out we don't need to compute the loadings manually, we can simply use the rotation matrix that comes out of PCA directly.

Closes #383 