### PR TITLE
tune external links

### DIFF
--- a/web/src/components/Landing.vue
+++ b/web/src/components/Landing.vue
@@ -177,7 +177,8 @@ v-app.viime-landing
             | extended across academia and industry with no restrictions. This includes deploying
             | VIIME at your institution for your internal research team. If you'd like to partner
             | with us to deploy or extend VIIME
-          v-btn.mt-3.mx-0.px-3(href="https://github.com/girder/viime", depressed, large)
+          v-btn.mt-3.mx-0.px-3(href="https://github.com/girder/viime", depressed, large,
+              target="_blank", rel="noopener noreferrer")
             v-icon.mr-2(left) $vuetify.icons.github
             | View on GitHub
         v-flex(pa-3, sm6)

--- a/web/src/components/Landing.vue
+++ b/web/src/components/Landing.vue
@@ -126,11 +126,12 @@ v-app.viime-landing
               h2 Kitware, Inc.
             v-card-text.pa-0
               v-list.team-members
-                v-list-tile(href="https://www.kitware.com/data-analytics/")
+                v-list-tile(href="https://www.kitware.com/data-analytics/",
+                    target="_blank", rel="noopener noreferrer")
                   v-list-tile-content
                     v-list-tile-title Data and Analytics team
                   v-list-tile-action
-                    v-icon(color="accent lighten-1") $vuetify.icons.link
+                    v-icon(color="accent lighten-1") $vuetify.icons.openInNew
         v-flex.partner(sm4)
           v-card.pa-3(color="transparent", flat)
             v-card-title.partner-title.pt-3(primary-title)
@@ -138,11 +139,12 @@ v-app.viime-landing
               h2 Indiana University
             v-card-text.pa-0
               v-list.team-members
-                v-list-tile(href="https://medicine.iu.edu/research/faculty-labs/oconnell/")
+                v-list-tile(href="https://medicine.iu.edu/research/faculty-labs/oconnell/",
+                    target="_blank", rel="noopener noreferrer")
                   v-list-tile-content
                     v-list-tile-title Thomas O'Connell
                   v-list-tile-action
-                    v-icon(color="accent lighten-1") $vuetify.icons.link
+                    v-icon(color="accent lighten-1") $vuetify.icons.openInNew
                 v-divider
                 v-list-tile
                   v-list-tile-content
@@ -159,11 +161,12 @@ v-app.viime-landing
               h2 University of Washington
             v-card-text.pa-0
               v-list.team-members
-                v-list-tile(href="https://sites.uw.edu/mmcslu/faculty/daniel-raftery-phd/")
+                v-list-tile(href="https://sites.uw.edu/mmcslu/faculty/daniel-raftery-phd/",
+                    target="_blank", rel="noopener noreferrer")
                   v-list-tile-content
                     v-list-tile-title Daniel Raftery
                   v-list-tile-action
-                    v-icon(color="accent lighten-1") $vuetify.icons.link
+                    v-icon(color="accent lighten-1") $vuetify.icons.openInNew
 
   .collaboration
     v-container

--- a/web/src/utils/vuetifyConfig.js
+++ b/web/src/utils/vuetifyConfig.js
@@ -65,5 +65,6 @@ export default {
     plusMultiple: 'mdi-checkbox-multiple-marked-outline',
     minusMultiple: 'mdi-checkbox-multiple-blank-outline',
     square: 'mdi-square',
+    openInNew: 'mdi-open-in-new',
   },
 };


### PR DESCRIPTION
use open-in-new icon since it links out to an external page + set proper target and rel attributes

![image](https://user-images.githubusercontent.com/4129778/68489569-5dd48900-0215-11ea-93ce-865efd79440c.png)
