### PR TITLE
Add browser support banner

### DIFF
--- a/web/src/components/BrowserSupportBanner.vue
+++ b/web/src/components/BrowserSupportBanner.vue
@@ -1,0 +1,19 @@
+<template lang="pug">
+v-toolbar(dense, color="warning", v-if="showBanner")
+  v-icon $vuetify.icons.warningCircle
+  v-toolbar-title Browser Unsupported
+  .subheading.px-4 Certain features require Chrome or Firefox
+</template>
+
+<script>
+import { getBrowser } from '../utils/mixins';
+
+export default {
+  mixins: [getBrowser],
+  computed: {
+    showBanner() {
+      return !(this.browser.isBlink || this.browser.isFirefox);
+    },
+  },
+};
+</script>

--- a/web/src/components/Landing.vue
+++ b/web/src/components/Landing.vue
@@ -1,9 +1,11 @@
 <script>
+import BrowserSupportBanner from './BrowserSupportBanner.vue';
 import HighlightImage from './HighlightImage.vue';
 import FeedbackButton from './FeedbackButton.vue';
 
 export default {
   components: {
+    BrowserSupportBanner,
     HighlightImage,
     FeedbackButton,
   },
@@ -19,6 +21,7 @@ export default {
 </script>
 <template lang="pug">
 v-app.viime-landing
+  browser-support-banner
   v-toolbar.main-toolbar.darken-4.py-2(dark, dense, color="transparent", flat)
     v-toolbar-title(style="height: 100%; padding: 10px 0;")
       img(src="../assets/viime_logo_ko.svg", alt="VIIME", height="100%")

--- a/web/src/components/ViimeApp.vue
+++ b/web/src/components/ViimeApp.vue
@@ -1,5 +1,6 @@
 <template lang="pug">
 v-app.viime-app
+  browser-support-banner
   v-toolbar.darken-3(dense, dark, color="primary")
     v-toolbar-side-icon.logo(:to="{name: 'Root'}") V
     v-breadcrumbs(:items="breadcrumbs", divider="»")
@@ -15,12 +16,14 @@ v-app.viime-app
 </template>
 
 <script>
+import BrowserSupportBanner from './BrowserSupportBanner.vue';
 import SaveStatus from './SaveStatus.vue';
 import FeedbackButton from './FeedbackButton.vue';
 
 export default {
   name: 'App',
   components: {
+    BrowserSupportBanner,
     SaveStatus,
     FeedbackButton,
   },

--- a/web/src/utils/mixins.js
+++ b/web/src/utils/mixins.js
@@ -24,6 +24,48 @@ const loadDataset = {
   },
 };
 
+// Adapted from https://stackoverflow.com/questions/9847580/how-to-detect-safari-chrome-ie-firefox-and-opera-browser
+const getBrowser = {
+  computed: {
+    browser() {
+      // Opera 8.0+
+      // eslint-disable-next-line no-undef
+      const isOpera = (!!window.opr && !!opr.addons) || !!window.opera || navigator.userAgent.indexOf(' OPR/') >= 0;
+
+      // Firefox 1.0+
+      const isFirefox = typeof InstallTrigger !== 'undefined';
+
+      // Safari 3.0+ "[object HTMLElementConstructor]"
+      // eslint-disable-next-line wrap-iife,func-names,quotes,dot-notation,no-undef
+      const isSafari = /constructor/i.test(window.HTMLElement) || (function (p) { return p.toString() === "[object SafariRemoteNotification]"; })(!window['safari'] || (typeof safari !== 'undefined' && safari.pushNotification));
+
+      // Internet Explorer 6-11
+      // eslint-disable-next-line spaced-comment
+      const isIE = /*@cc_on!@*/false || !!document.documentMode;
+
+      // Edge 20+
+      const isEdge = !isIE && !!window.StyleMedia;
+
+      // Chrome 1 - 71
+      const isChrome = !!window.chrome && (!!window.chrome.webstore || !!window.chrome.runtime);
+
+      // Blink engine detection
+      const isBlink = (isChrome || isOpera) && !!window.CSS;
+
+      return {
+        isOpera,
+        isFirefox,
+        isSafari,
+        isIE,
+        isEdge,
+        isChrome,
+        isBlink,
+      };
+    },
+  },
+};
+
 export {
+  getBrowser,
   loadDataset,
 };


### PR DESCRIPTION
Didn't really want to add an external dependency.  Found the best implementation on S/O and dropped it into a mixin.  I agree with https://stackoverflow.com/questions/9847580/how-to-detect-safari-chrome-ie-firefox-and-opera-browser that this is better than user agent parsing.

Going to leave #437 open because this doesn't really resolve any bugs.

![Screenshot from 2019-11-12 13-59-06](https://user-images.githubusercontent.com/4214172/68701423-ba58e080-0554-11ea-9949-23ad2301fb09.png)
