### PR TITLE
Sample dialog

### DIFF
--- a/web/src/components/SampleBrowser.vue
+++ b/web/src/components/SampleBrowser.vue
@@ -67,11 +67,13 @@ export default {
 .import {
   flex: 0 0 auto;
 }
+
 .sample-panels {
   border-bottom: 1px solid var(--v-primary-lighten4);
   border-top: 1px solid var(--v-primary-lighten4);
-  .v-expansion-panel__body {
-    background: var(--v-primary-lighten-5);
+
+  /deep/ .v-expansion-panel__body {
+    background: var(--v-primary-lighten5);
     box-shadow: inset 0px 0px 4px rgba(0, 0, 0, .25);
   }
 }

--- a/web/src/components/SampleBrowser.vue
+++ b/web/src/components/SampleBrowser.vue
@@ -41,22 +41,22 @@ export default {
     v-progress-circular(indeterminate, color="primary")
   v-alert(:value="!loading && samples.length === 0", type="info")
     | No Sample Data Sources available
-  v-expansion-panel(v-if="!loading && samples.length > 0", :value="0")
+  v-expansion-panel.elevation-0(v-if="!loading && samples.length > 0", :value="0")
     v-expansion-panel-content.group(v-for="group,index in samples", :key="group.name",
         :readonly="samples.length === 1")
       template(#header)
         span {{ group.name }}
         v-btn.import(color="primary", @click="importGroup(group.name, $event)") Import All
 
-      v-card
-        v-card-text
+      v-card(color="primary lighten-5")
+        v-card-text.pa-4
           | {{ group.description || 'no description available' }}
 
-      v-expansion-panel
+      v-expansion-panel.pb-3.px-3
         v-expansion-panel-content.file(v-for="file in group.files", :key="file.id")
           template(#header)
             span {{ file.name }}
-            v-btn.import(color="primary", @click="importSample(file.id, $event)") Import
+            v-btn.import(color="primary", @click="importSample(file.id, $event)", flat) Import
 
           v-card
             v-card-text

--- a/web/src/components/SampleBrowser.vue
+++ b/web/src/components/SampleBrowser.vue
@@ -41,18 +41,18 @@ export default {
     v-progress-circular(indeterminate, color="primary")
   v-alert(:value="!loading && samples.length === 0", type="info")
     | No Sample Data Sources available
-  v-expansion-panel.elevation-0(v-if="!loading && samples.length > 0", :value="0")
+  v-expansion-panel.sample-panels.elevation-0(v-if="!loading && samples.length > 0", :value="0")
     v-expansion-panel-content.group(v-for="group,index in samples", :key="group.name",
         :readonly="samples.length === 1")
       template(#header)
         span {{ group.name }}
         v-btn.import(color="primary", @click="importGroup(group.name, $event)") Import All
 
-      v-card(color="primary lighten-5")
+      v-card(color="transparent")
         v-card-text.pa-4
           | {{ group.description || 'no description available' }}
 
-      v-expansion-panel.pb-3.px-3
+      v-expansion-panel.pb-4.px-4.elevation-0
         v-expansion-panel-content.file(v-for="file in group.files", :key="file.id")
           template(#header)
             span {{ file.name }}
@@ -66,5 +66,13 @@ export default {
 <style scoped lang="scss">
 .import {
   flex: 0 0 auto;
+}
+.sample-panels {
+  border-bottom: 1px solid var(--v-primary-lighten4);
+  border-top: 1px solid var(--v-primary-lighten4);
+  .v-expansion-panel__body {
+    background: var(--v-primary-lighten-5);
+    box-shadow: inset 0px 0px 4px rgba(0, 0, 0, .25);
+  }
 }
 </style>

--- a/web/src/components/Upload.vue
+++ b/web/src/components/Upload.vue
@@ -169,7 +169,7 @@ v-layout.upload-component(column, fill-height)
           v-card
             v-card-title
               h3.headline Examples
-            v-card-text
+            v-card-text.pa-0
               sample-browser(@close="browseSamples = false")
             v-card-actions
               v-spacer


### PR DESCRIPTION
Took a stab at making this look a bit better. I did not have sample data in my local copy, so I was sort of styling blind, but I think this should help, at least.

<img width="635" alt="Screen Shot 2019-11-13 at 11 34 56 AM" src="https://user-images.githubusercontent.com/1560779/68784061-f8640c00-0609-11ea-954e-46fb71bc501d.png">
