### PR TITLE
Sgratzl/numericgroups

### DIFF
--- a/viime/models.py
+++ b/viime/models.py
@@ -720,7 +720,11 @@ def _get_sample_metadata(csv_file):
 def _get_groups(csv_file):
     if csv_file.group_column_index is None:
         return None
-    return csv_file.filter_table_by_types(TABLE_ROW_TYPES.DATA, TABLE_COLUMN_TYPES.GROUP)
+    groups = csv_file.filter_table_by_types(TABLE_ROW_TYPES.DATA, TABLE_COLUMN_TYPES.GROUP)
+    if groups is None:
+        return None
+    # ensure groups are strings
+    return groups.astype(str)
 
 
 @csv_file_cache

--- a/viime/models.py
+++ b/viime/models.py
@@ -724,7 +724,7 @@ def _get_groups(csv_file):
     if groups is None:
         return None
     # ensure groups are strings
-    return groups.astype(str)
+    return groups.fillna('').astype(str)
 
 
 @csv_file_cache

--- a/web/src/components/CleanupDataTable.vue
+++ b/web/src/components/CleanupDataTable.vue
@@ -33,12 +33,21 @@ export default {
     columns() {
       const rows = this.dataset.sourcerows;
 
+      const rowTypes = this.dataset.row.labels;
+
+      const f = (v, colType, rowType) => {
+        if (colType !== 'measurement' || rowType !== 'sample') {
+          return v;
+        }
+        return formatter(v);
+      };
+
       return this.dataset.column.labels.map((colType, i) => {
         const column = {
           index: i,
           header: this.createHeader(colType, defaultColOption, base26Converter(i + 1)),
           clazz: [`type-${colType}`],
-          values: rows.map(row => formatter(row[i])),
+          values: rows.map((row, r) => f(row[i], colType, rowTypes[r])),
         };
         const selected = this.getSelectionClasses('column', i);
         column.clazz.push(...selected);
@@ -119,7 +128,7 @@ export default {
       if (columnType !== 'group' || rowType !== 'sample') {
         return null;
       }
-      const color = this.groupToColor(value);
+      const color = this.groupToColor(String(value));
       const tColor = textColor(color);
       return {
         backgroundColor: color,


### PR DESCRIPTION
closes #469 

![image](https://user-images.githubusercontent.com/4129778/68806192-5a853700-0633-11ea-9451-d97afebfd9a1.png)

two relevant changes:
 1. enforces that the group data frame is a string
 2. show only values (sample x measurement) formatted otherwise show the value as is
