### PR TITLE
Fix score plot wonkiness

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -56,7 +56,7 @@
     "eslint": "^5.8.0",
     "eslint-plugin-vue": "^5.0.0",
     "git-revision-webpack-plugin": "^3.0.3",
-    "node-sass": "^4.11.0",
+    "node-sass": "^4.13.0",
     "pug": "^2.0.3",
     "pug-lint-vue": "^0.1.3",
     "pug-plain-loader": "^1.0.0",

--- a/web/src/components/vis/ScorePlot.vue
+++ b/web/src/components/vis/ScorePlot.vue
@@ -482,18 +482,6 @@ export default {
         xs[g] = xName;
       });
 
-      // The following side effect depends on xData and yData in the same way
-      // that the C3 chart itself does, so we disable the linter warning that would
-      // prevent it.
-      //
-      // In general, this is part of the tradeoff of mixing an imperative vis
-      // library like C3 with a reactive framework like Vue. The alternatives are
-      // less attractive than breaking the rules here: for instance, we could set a
-      // series of watchers on the dependencies of this function to explicitly
-      // trigger it, but that presents a serious danger of falling out of sync with
-      // changes in the dependency list.
-      //
-      // eslint-disable-next-line vue/no-side-effects-in-computed-properties
       this.labels = labels;
 
       // Collect the existing and incoming column names.

--- a/web/src/components/vis/ScorePlot.vue
+++ b/web/src/components/vis/ScorePlot.vue
@@ -447,7 +447,7 @@ export default {
       } = this.updateDeps;
 
       if (!valid) {
-        return '';
+        return;
       }
 
       const fmt = format('.2%');
@@ -561,8 +561,6 @@ export default {
             .style('opacity', 0)
             .remove(),
         );
-
-      return String(Math.random());
     },
   },
 };

--- a/web/src/components/vis/ScorePlot.vue
+++ b/web/src/components/vis/ScorePlot.vue
@@ -14,7 +14,6 @@ import resize from 'vue-resize-directive';
 import 'c3/c3.css';
 import './score-plot.css';
 
-
 function fixCSS(id) {
   // replace non css stuff to _
   return id.replace(/[\s!#$%&'()*+,./:;<=>?@[\\\]^`{|}~]+/g, '_');
@@ -218,7 +217,7 @@ export default {
         && eigenvalues.length > 0;
     },
 
-    update() {
+    updateDeps() {
       const {
         colorMapping,
         pcPoints,
@@ -233,115 +232,25 @@ export default {
         height,
       } = this;
 
-      if (!valid) {
-        return '';
-      }
-
-      const fmt = format('.2%');
-      const x = `PC${pcX} (${fmt(pcVariances[0])})`;
-      const y = `PC${pcY} (${fmt(pcVariances[1])})`;
-
-      this.chart.axis.labels({
-        x,
-        y,
-      });
-
-      this.chart.resize({
+      return {
+        colorMapping,
+        pcPoints,
+        pcX,
+        pcY,
+        showEllipses,
+        ellipseVisible,
+        duration,
+        pcVariances,
+        valid,
         width,
         height,
-      });
+      };
+    },
+  },
 
-      const [xData, yData] = pcPoints;
-      const grouped = this.grouped(xData, yData);
-
-      const groups = Object.keys(grouped);
-      const columns = [];
-      const labels = {};
-      const xs = {};
-      groups.forEach((g) => {
-        const xName = `${g}_x`;
-
-        columns.push([xName, ...grouped[g].map(d => d.x)]);
-        columns.push([g, ...grouped[g].map(d => d.y)]);
-
-        labels[g] = [...grouped[g].map(d => d.label)];
-
-        xs[g] = xName;
-      });
-
-      // The following side effect depends on xData and yData in the same way
-      // that the C3 chart itself does, so we disable the linter warning that would
-      // prevent it.
-      //
-      // In general, this is part of the tradeoff of mixing an imperative vis
-      // library like C3 with a reactive framework like Vue. The alternatives are
-      // less attractive than breaking the rules here: for instance, we could set a
-      // series of watchers on the dependencies of this function to explicitly
-      // trigger it, but that presents a serious danger of falling out of sync with
-      // changes in the dependency list.
-      //
-      // eslint-disable-next-line vue/no-side-effects-in-computed-properties
-      this.labels = labels;
-
-      // Draw the C3 chart.
-      this.chart.unload();
-      this.chart.load({
-        columns,
-        xs,
-      });
-
-      // Set the colors.
-      this.chart.data.colors(colorMapping);
-
-      // Draw the data ellipses.
-      const scaleX = this.chart.internal.x;
-      const scaleY = this.chart.internal.y;
-      const cmap = this.chart.internal.color;
-
-      const confidenceEllipses = Object.keys(grouped).map(group => ({
-        ...confidenceEllipse(grouped[group].map(d => d.x), grouped[group].map(d => d.y), 1),
-        category: group,
-      }));
-      confidenceEllipses.forEach((ell) => {
-        if (ellipseVisible[ell.category] === undefined) {
-          ellipseVisible[ell.category] = true;
-        }
-      });
-
-      const xFactor = (scaleX(1e10) - scaleX(0)) / 1e10;
-      const yFactor = (scaleY(1e10) - scaleY(0)) / 1e10;
-      const plotTransform = `translate(${scaleX(0)} ${scaleY(0)}) scale(${xFactor} ${yFactor})`;
-      select(this.$refs.chart)
-        .select('.c3-custom-ellipses')
-        .selectAll('ellipse')
-        .data(confidenceEllipses)
-        .join(
-          enter => enter
-            .append('ellipse')
-            .attr('class', d => `ellipse-${fixCSS(d.category)}`)
-            .classed('ellipse', true)
-            .style('fill', 'none')
-            .style('stroke', d => cmap(d.category))
-            .style('stroke-width', 1)
-            .attr('vector-effect', 'non-scaling-stroke')
-            .attr('rx', d => d.rx)
-            .attr('ry', d => d.ry)
-            .attr('transform', d => `${plotTransform} ${d.transform}`)
-            .style('opacity', 1),
-          update => update
-            .style('display', d => (showEllipses && ellipseVisible[d.category] ? null : 'none'))
-            .transition()
-            .duration(300)
-            .attr('rx', d => d.rx)
-            .attr('ry', d => d.ry)
-            .attr('transform', d => `${plotTransform} ${d.transform}`),
-          exit => exit.transition('exit')
-            .duration(duration)
-            .style('opacity', 0)
-            .remove(),
-        );
-
-      return String(Math.random());
+  watch: {
+    updateDeps() {
+      this.update();
     },
   },
 
@@ -490,6 +399,133 @@ export default {
       const bb = this.$el.getBoundingClientRect();
       this.width = bb.width - 20;
       this.height = bb.height;
+    },
+
+    update() {
+      const {
+        colorMapping,
+        pcPoints,
+        pcX,
+        pcY,
+        showEllipses,
+        ellipseVisible,
+        duration,
+        pcVariances,
+        valid,
+        width,
+        height,
+      } = this.updateDeps;
+
+      if (!valid) {
+        return '';
+      }
+
+      const fmt = format('.2%');
+      const x = `PC${pcX} (${fmt(pcVariances[0])})`;
+      const y = `PC${pcY} (${fmt(pcVariances[1])})`;
+
+      this.chart.axis.labels({
+        x,
+        y,
+      });
+
+      this.chart.resize({
+        width,
+        height,
+      });
+
+      const [xData, yData] = pcPoints;
+      const grouped = this.grouped(xData, yData);
+
+      const groups = Object.keys(grouped);
+      const columns = [];
+      const labels = {};
+      const xs = {};
+      groups.forEach((g) => {
+        const xName = `${g}_x`;
+
+        columns.push([xName, ...grouped[g].map(d => d.x)]);
+        columns.push([g, ...grouped[g].map(d => d.y)]);
+
+        labels[g] = [...grouped[g].map(d => d.label)];
+
+        xs[g] = xName;
+      });
+
+      // The following side effect depends on xData and yData in the same way
+      // that the C3 chart itself does, so we disable the linter warning that would
+      // prevent it.
+      //
+      // In general, this is part of the tradeoff of mixing an imperative vis
+      // library like C3 with a reactive framework like Vue. The alternatives are
+      // less attractive than breaking the rules here: for instance, we could set a
+      // series of watchers on the dependencies of this function to explicitly
+      // trigger it, but that presents a serious danger of falling out of sync with
+      // changes in the dependency list.
+      //
+      // eslint-disable-next-line vue/no-side-effects-in-computed-properties
+      this.labels = labels;
+
+      // Draw the C3 chart.
+      this.chart.unload();
+      this.chart.load({
+        columns,
+        xs,
+      });
+
+      // Set the colors.
+      this.chart.data.colors(colorMapping);
+
+      // Draw the data ellipses.
+      const scaleX = this.chart.internal.x;
+      const scaleY = this.chart.internal.y;
+      const cmap = this.chart.internal.color;
+
+      const confidenceEllipses = Object.keys(grouped).map(group => ({
+        ...confidenceEllipse(grouped[group].map(d => d.x), grouped[group].map(d => d.y), 1),
+        category: group,
+      }));
+
+      confidenceEllipses.forEach((ell) => {
+        if (ellipseVisible[ell.category] === undefined) {
+          ellipseVisible[ell.category] = true;
+        }
+      });
+
+      const xFactor = (scaleX(1e10) - scaleX(0)) / 1e10;
+      const yFactor = (scaleY(1e10) - scaleY(0)) / 1e10;
+      const plotTransform = `translate(${scaleX(0)} ${scaleY(0)}) scale(${xFactor} ${yFactor})`;
+      select(this.$refs.chart)
+        .select('.c3-custom-ellipses')
+        .selectAll('ellipse')
+        .data(confidenceEllipses)
+        .join(
+          enter => enter
+            .append('ellipse')
+            .attr('class', d => `ellipse-${fixCSS(d.category)}`)
+            .classed('ellipse', true)
+            .style('fill', 'none')
+            .style('stroke', d => cmap(d.category))
+            .style('stroke-width', 1)
+            .attr('vector-effect', 'non-scaling-stroke')
+            .attr('rx', d => d.rx)
+            .attr('ry', d => d.ry)
+            .attr('transform', d => `${plotTransform} ${d.transform}`)
+            .style('opacity', 1),
+          update => update
+            .style('display', d => (showEllipses && ellipseVisible[d.category] ? null : 'none'))
+            .transition()
+            .duration(300)
+            .attr('rx', d => d.rx)
+            .attr('ry', d => d.ry)
+            .attr('transform', d => `${plotTransform} ${d.transform}`),
+          exit => exit.transition('exit')
+            .duration(duration)
+            .style('opacity', 0)
+            .remove(),
+        );
+
+      return String(Math.random());
     },
   },
 };

--- a/web/src/components/vis/ScorePlot.vue
+++ b/web/src/components/vis/ScorePlot.vue
@@ -164,14 +164,6 @@ export default {
       duration: 500,
       width: 100,
       height: 100,
-
-      // This property is set to `true` in the mounted hook, and is necessary to
-      // prevent reactively calling `update()` before the component has mounted.
-      //
-      // The alternative would be to make `update()` into a method, then set a
-      // series of watchers based on its dependent properties, which results in a
-      // code duplication that would likely become a source of difficulties.
-      hasMounted: false,
     };
   },
 
@@ -237,11 +229,9 @@ export default {
         rowLabels,
         groupLabels,
         eigenvalues,
-        hasMounted,
       } = this;
 
-      return hasMounted
-        && pcCoords.length > 0
+      return pcCoords.length > 0
         && rowLabels.length > 0
         && Object.keys(groupLabels).length > 0
         && eigenvalues.length > 0;
@@ -285,8 +275,6 @@ export default {
   },
 
   mounted() {
-    this.hasMounted = true;
-
     this.chart = c3.generate({
       bindto: this.$refs.chart,
       data: {

--- a/web/src/components/vis/ScorePlot.vue
+++ b/web/src/components/vis/ScorePlot.vue
@@ -103,7 +103,7 @@ export default {
     rowLabels: {
       required: true,
       type: Array,
-      validator: prop => prop.every(val => typeof val === 'string'),
+      validator: prop => prop.every(val => typeof val !== 'object'),
     },
     colors: {
       required: true,

--- a/web/src/components/vis/ScorePlot.vue
+++ b/web/src/components/vis/ScorePlot.vue
@@ -14,9 +14,15 @@ import resize from 'vue-resize-directive';
 import 'c3/c3.css';
 import './score-plot.css';
 
-function delay(ms) {
+// This function uses C3's `done` API to return a promise that can be awaited,
+// averting the need to place the continuation of the function it's embedded in
+// into the done callback.
+function c3LoadWait(chart, opts) {
   return new Promise((resolve, reject) => {
-    window.setTimeout(() => resolve(), ms);
+    chart.load({
+      ...opts,
+      done: () => resolve(),
+    });
   });
 }
 
@@ -497,7 +503,7 @@ export default {
 
       // Draw the C3 chart, unloding the existing data first if the column names
       // have changed.
-      this.chart.load({
+      await c3LoadWait(this.chart, {
         columns,
         xs,
         unload: !sameContents(oldCols, newCols),
@@ -505,8 +511,6 @@ export default {
 
       // Set the colors.
       this.chart.data.colors(colorMapping);
-
-      await delay(0);
 
       // Draw the data ellipses.
       const scaleX = this.chart.internal.x;

--- a/web/src/components/vis/ScorePlot.vue
+++ b/web/src/components/vis/ScorePlot.vue
@@ -544,6 +544,8 @@ export default {
             .attr('transform', d => d.transform)
             .style('opacity', 1),
           update => update
+            .attr('class', d => `ellipse-${fixCSS(d.category)}`)
+            .classed('ellipse', true)
             .style('display', d => (showEllipses && ellipseVisible[d.category] ? null : 'none'))
             .transition()
             .duration(300)

--- a/web/src/components/vis/ScorePlot.vue
+++ b/web/src/components/vis/ScorePlot.vue
@@ -14,6 +14,20 @@ import resize from 'vue-resize-directive';
 import 'c3/c3.css';
 import './score-plot.css';
 
+function sameContents(a, b) {
+  if (a.length !== b.length) {
+    return false;
+  }
+
+  for (let i = 0; i < a.length; i++) {
+    if (a[i] !== b[i]) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
 function fixCSS(id) {
   // replace non css stuff to _
   return id.replace(/[\s!#$%&'()*+,./:;<=>?@[\\\]^`{|}~]+/g, '_');
@@ -466,11 +480,17 @@ export default {
       // eslint-disable-next-line vue/no-side-effects-in-computed-properties
       this.labels = labels;
 
-      // Draw the C3 chart.
-      this.chart.unload();
+      // Collect the existing and incoming column names.
+      const oldCols = this.chart.data().map(d => d.id);
+      const newCols = columns.map(d => d[0])
+        .filter(d => !d.endsWith('_x'));
+
+      // Draw the C3 chart, unloding the existing data first if the column names
+      // have changed.
       this.chart.load({
         columns,
         xs,
+        unload: !sameContents(oldCols, newCols),
       });
 
       // Set the colors.

--- a/web/src/components/vis/ScorePlot.vue
+++ b/web/src/components/vis/ScorePlot.vue
@@ -18,7 +18,7 @@ import './score-plot.css';
 // averting the need to place the continuation of the function it's embedded in
 // into the done callback.
 function c3LoadWait(chart, opts) {
-  return new Promise((resolve, reject) => {
+  return new Promise((resolve) => {
     chart.load({
       ...opts,
       done: () => resolve(),
@@ -31,7 +31,7 @@ function sameContents(a, b) {
     return false;
   }
 
-  for (let i = 0; i < a.length; i++) {
+  for (let i = 0; i < a.length; i += 1) {
     if (a[i] !== b[i]) {
       return false;
     }
@@ -102,7 +102,7 @@ function confidenceEllipse(x, y, std, xScale, yScale) {
   return {
     rx: ell_radius_x,
     ry: ell_radius_y,
-    transform
+    transform,
   };
 }
 
@@ -493,10 +493,15 @@ export default {
       const scaleY = this.chart.internal.y;
       const cmap = this.chart.internal.color;
 
-      const confidenceEllipses = Object.keys(grouped).map(group => ({
-        ...confidenceEllipse(grouped[group].map(d => d.x), grouped[group].map(d => d.y), 1, scaleX, scaleY),
-        category: group,
-      }));
+      const confidenceEllipses = Object.keys(grouped).map((group) => {
+        const groupx = grouped[group].map(d => d.x);
+        const groupy = grouped[group].map(d => d.y);
+
+        return {
+          ...confidenceEllipse(groupx, groupy, 1, scaleX, scaleY),
+          category: group,
+        };
+      });
 
       confidenceEllipses.forEach((ell) => {
         if (ellipseVisible[ell.category] === undefined) {
@@ -504,8 +509,6 @@ export default {
         }
       });
 
-      const xFactor = (scaleX(1e10) - scaleX(0)) / 1e10;
-      const yFactor = (scaleY(1e10) - scaleY(0)) / 1e10;
       select(this.$refs.chart)
         .select('.c3-custom-ellipses')
         .selectAll('ellipse')

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -6572,10 +6572,6 @@ locate-path@^3.0.0:
     p-locate "^3.0.0"
     path-exists "^3.0.0"
 
-lodash.assign@^4.2.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/lodash.assign/-/lodash.assign-4.2.0.tgz#0d99f3ccd7a6d261d19bdaeb9245005d285808e7"
-
 lodash.assignin@^4.0.9:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/lodash.assignin/-/lodash.assignin-4.2.0.tgz#ba8df5fb841eb0a3e8044232b0e263a8dc6a28a2"
@@ -6584,7 +6580,7 @@ lodash.bind@^4.1.4:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/lodash.bind/-/lodash.bind-4.2.1.tgz#7ae3017e939622ac31b7d7d7dcb1b34db1690d35"
 
-lodash.clonedeep@^4.3.2, lodash.clonedeep@^4.5.0:
+lodash.clonedeep@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz#e23f3f9c4f8fbdde872529c1071857a086e5ccef"
 
@@ -6635,11 +6631,6 @@ lodash.merge@^4.4.0:
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
   integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
 
-lodash.mergewith@^4.6.0:
-  version "4.6.2"
-  resolved "https://registry.yarnpkg.com/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz#617121f89ac55f59047c7aec1ccd6654c6590f55"
-  integrity sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ==
-
 lodash.pick@^4.2.1:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.pick/-/lodash.pick-4.4.0.tgz#52f05610fff9ded422611441ed1fc123a03001b3"
@@ -6676,6 +6667,11 @@ lodash@4.x, lodash@^4.0.0, lodash@^4.13.1, lodash@^4.17.10, lodash@^4.17.11, lod
   version "4.17.13"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.13.tgz#0bdc3a6adc873d2f4e0c4bac285df91b64fc7b93"
   integrity sha512-vm3/XWXfWtRua0FkUyEHBZy8kCPjErNBT9fJx8Zvs+U6zjqPbTUOpkaoum3O5uiA8sm+yNMHXfYkTUHFoMxFNA==
+
+lodash@^4.17.15:
+  version "4.17.15"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
+  integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
 
 log-symbols@^2.2.0:
   version "2.2.0"
@@ -7075,7 +7071,12 @@ mute-stream@0.0.7:
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.7.tgz#3075ce93bc21b8fab43e1bc4da7e8115ed1e7bab"
 
-nan@^2.10.0, nan@^2.9.2:
+nan@^2.13.2:
+  version "2.14.0"
+  resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.0.tgz#7818f722027b2459a86f0295d434d1fc2336c52c"
+  integrity sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==
+
+nan@^2.9.2:
   version "2.12.1"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.12.1.tgz#7b1aa193e9aa86057e3c7bbd0ac448e770925552"
 
@@ -7229,9 +7230,10 @@ node-releases@^1.1.3:
   dependencies:
     semver "^5.3.0"
 
-node-sass@^4.11.0:
-  version "4.11.0"
-  resolved "https://registry.yarnpkg.com/node-sass/-/node-sass-4.11.0.tgz#183faec398e9cbe93ba43362e2768ca988a6369a"
+node-sass@^4.13.0:
+  version "4.13.0"
+  resolved "https://registry.yarnpkg.com/node-sass/-/node-sass-4.13.0.tgz#b647288babdd6a1cb726de4545516b31f90da066"
+  integrity sha512-W1XBrvoJ1dy7VsvTAS5q1V45lREbTlZQqFbiHb3R3OTTCma0XBtuG6xZ6Z4506nR4lmHPTqVRwxT6KgtWC97CA==
   dependencies:
     async-foreach "^0.1.3"
     chalk "^1.1.1"
@@ -7240,12 +7242,10 @@ node-sass@^4.11.0:
     get-stdin "^4.0.1"
     glob "^7.0.3"
     in-publish "^2.0.0"
-    lodash.assign "^4.2.0"
-    lodash.clonedeep "^4.3.2"
-    lodash.mergewith "^4.6.0"
+    lodash "^4.17.15"
     meow "^3.7.0"
     mkdirp "^0.5.1"
-    nan "^2.10.0"
+    nan "^2.13.2"
     node-gyp "^3.8.0"
     npmlog "^4.0.0"
     request "^2.88.0"


### PR DESCRIPTION
This PR performs a number of code transformations in order to eliminate some of the weird chart behaviors we've been seeing:
1. It moves the `update()` function out of computed properties and into a method. This seems to eliminate strange issues resulting from our abuse of Vue's reactivity system.
2. It performs a conditional `unload` of C3's data, depending on if the column names have changed (as happens specifically when the dataset is changed in Viime).
3. It computes the SVG transforms for confidence ellipses using the D3 scale objects, rather than chaining separate transforms together (resulting in simpler code and simpler transforms in the end).
4. It makes proper use of C3's load/unload API to ensure that the scale objects used in (3) above are the correct ones.

The PR introduces a new code pattern. Since we want `update()` called reactively on its dependencies, I have abstracted the dependencies themselves out into a computed property, set a watcher on that property that simply calls `update()`, and I've made sure to write `update()` such that it *only* takes props from the computed dependency property, and nowhere else. This is one of the tradeoffs needed in structuring the code this way (it replaces the earlier tradeoff of abusing the reactivity system).

Closes #484.
Depends on #486.