### PR TITLE
Remove persistent cache region

### DIFF
--- a/viime/app.py
+++ b/viime/app.py
@@ -7,15 +7,10 @@ from marshmallow import ValidationError
 from webargs.flaskparser import parser
 from werkzeug.middleware.proxy_fix import ProxyFix
 
-from viime.cache import clear_cache, persistent_region
+from viime.cache import clear_cache
 from viime.models import db
 from viime.opencpu import OpenCPUException
 from viime.views import csv_bp
-
-try:
-    import pylibmc
-except ImportError:
-    pylibmc = None
 
 
 def handle_validation_error(e):
@@ -82,16 +77,6 @@ def create_app(config=None):
     app.register_error_handler(OpenCPUException, handle_opencpu_error)
     if app.config['ENV'] == 'production':
         app.register_error_handler(500, handle_general_error)
-
-    if 'MEMCACHED_URI' in os.environ and pylibmc:
-        persistent_region.configure(
-            'dogpile.cache.pylibmc',
-            arguments={
-                'url': os.environ['MEMCACHED_URI'],
-                'binary': True
-            },
-            replace_existing_backend=True
-        )
 
     @app.after_request
     def clear_cache_after_request(response):

--- a/viime/cache.py
+++ b/viime/cache.py
@@ -8,23 +8,6 @@ from flask import g
 from pandas.core.base import PandasObject
 from pandas.util import hash_pandas_object
 
-_cache_registry = []
-
-
-def csv_file_cache(func):
-    """Cache the results of a function acting on a csv file.
-
-    The purpose of this decorator is to wrap the dogpile decorator, `cache_on_argument`.
-    It keeps a registry of functions that have been decorated and adds the ability
-    to purge the cache for all function calls on a specific model.
-
-    ** This decorator only works with functions taking a single csv_file object as
-    ** an argument.
-    """
-    func = persistent_region.cache_on_arguments()(func)
-    _cache_registry.append(func)
-    return func
-
 
 def hash_argument(arg):
     from viime.models import CSVFile, TableColumn, TableRow
@@ -47,9 +30,6 @@ def mangle_key(key):
 
 def clear_cache(csv_file=None):
     g.cache = {}
-    if csv_file:
-        for func in _cache_registry:
-            func.invalidate(csv_file)
 
 
 class FlaskRequestLocalBackend(MemoryBackend):
@@ -69,11 +49,3 @@ region = make_region(
     function_key_generator=partial(kwarg_function_key_generator, to_str=hash_argument)
 )
 region.configure('flask_request_local')
-
-
-persistent_region = make_region(
-    'viime.app.persistent',
-    function_key_generator=partial(kwarg_function_key_generator, to_str=hash_argument),
-    key_mangler=mangle_key
-)
-persistent_region.configure('dogpile.cache.null')

--- a/viime/models.py
+++ b/viime/models.py
@@ -21,7 +21,7 @@ from sqlalchemy_utils.types.json import JSONType
 from sqlalchemy_utils.types.uuid import UUIDType
 from werkzeug.utils import secure_filename
 
-from viime.cache import clear_cache, csv_file_cache, region
+from viime.cache import clear_cache, region
 from viime.colors import category10
 from viime.imputation import IMPUTE_MCAR_METHODS, impute_missing, IMPUTE_MNAR_METHODS
 from viime.normalization import NORMALIZATION_METHODS, normalize
@@ -692,12 +692,10 @@ def _coerce_numeric(table):
 # The following methods are stored in a persistent cache (memcached) if configured.
 # They are for more complicated functions that could take significant time to execute
 # and are commonly called between multiple rest endpoints with the same value.
-@csv_file_cache
 def _get_raw_measurement_table(csv_file):
     return csv_file.filter_table_by_types(TABLE_ROW_TYPES.DATA, TABLE_COLUMN_TYPES.DATA)
 
 
-@csv_file_cache
 def _get_measurement_table_and_info(csv_file):
     if not get_fatal_index_errors(csv_file):
         try:
@@ -708,17 +706,14 @@ def _get_measurement_table_and_info(csv_file):
     return None, dict(mcar=[], mnar=[])
 
 
-@csv_file_cache
 def _get_measurement_metadata(csv_file):
     return csv_file.filter_table_by_types(TABLE_ROW_TYPES.METADATA, TABLE_COLUMN_TYPES.DATA)
 
 
-@csv_file_cache
 def _get_sample_metadata(csv_file):
     return csv_file.filter_table_by_types(TABLE_ROW_TYPES.DATA, TABLE_COLUMN_TYPES.METADATA)
 
 
-@csv_file_cache
 def _get_groups(csv_file):
     if csv_file.group_column_index is None:
         return None
@@ -729,7 +724,6 @@ def _get_groups(csv_file):
     return groups.fillna('').astype(str)
 
 
-@csv_file_cache
 def _get_csv_file_stats(csv_file):
     if csv_file.raw_measurement_table is not None:
         return _get_table_stats(csv_file.raw_measurement_table)

--- a/viime/normalization.py
+++ b/viime/normalization.py
@@ -1,8 +1,6 @@
 from marshmallow import ValidationError
 from sklearn import preprocessing
 
-from viime.cache import persistent_region
-
 NORMALIZATION_METHODS = {'minmax', 'sum', 'reference-sample', 'weight-volume'}
 
 
@@ -15,7 +13,6 @@ def validate_normalization_method(args):
         raise ValidationError('Method requires argument', data=argument)
 
 
-@persistent_region.cache_on_arguments()
 def normalize(method, table, argument=None, measurement_metadata=None, sample_metadata=None):
     if method is None:
         pass

--- a/viime/views.py
+++ b/viime/views.py
@@ -12,7 +12,6 @@ from werkzeug.datastructures import FileStorage
 
 from viime import opencpu, samples
 from viime.analyses import anova_test, hierarchical_clustering, pairwise_correlation, wilcoxon_test
-from viime.cache import csv_file_cache
 from viime.imputation import IMPUTE_MCAR_METHODS, IMPUTE_MNAR_METHODS
 from viime.models import AXIS_NAME_TYPES, CSVFile, CSVFileSchema, db, \
     GroupLevelSchema, ModifyLabelListSchema, \
@@ -48,7 +47,6 @@ def load_validated_csv_file(func):
     return wrapped
 
 
-@csv_file_cache
 def _serialize_csv_file(csv_file):
     csv_file_schema = CSVFileSchema()
     return csv_file_schema.dump(csv_file)


### PR DESCRIPTION
This address two ongoing issues:
1. Errors resulting from caching objects greater than 1MB
2. Errors/inconsistent results from stale cache

As we have discussed, the inter-request caching was not actually providing any positive benefits due to how the client was making requests.  In the future, if we want to add back caching we will have to experiment with another backend (probably redis).

I don't know if this will fix the priority issue, but it is my first 0-effort guess.