### PR TITLE
Throw an error object in boxplot render

### DIFF
--- a/web/src/components/vis/BoxPlot.vue
+++ b/web/src/components/vis/BoxPlot.vue
@@ -167,6 +167,8 @@ export default {
           .html((d, i) => (i === 0
             ? `<title>${d.name}: ${f(d.whiskers[0].start)} (q1-iqr*1.5) - ${f(d.fiveNums[1])} (q1) = ${count(d.values, d.whiskers[0].start, d.fiveNums[1])} Items</title>`
             : `<title>${d.name}: ${f(d.fiveNums[3])} (q3) - ${f(d.whiskers[1].start)} (q3+iqr*1.5) = ${count(d.values, d.fiveNums[3], d.whiskers[1].start)} Items</title>`));
+      }).catch(() => {
+        throw new Error('BoxPlot draw failed');
       });
     },
   },


### PR DESCRIPTION
Currently when an error is thrown in this code, it is thrown as a data object so sentry detects each time it happens as a unique issue.  I don't know why there is an error being thrown here, or why the box plot is even being drawn on page load.  This will at least prevent sentry issue spam from continuing.