### PR TITLE
Add a switch to turn off heatmap's "dendrogram mode"

### DIFF
--- a/viime/analyses.py
+++ b/viime/analyses.py
@@ -65,7 +65,10 @@ def hierarchical_clustering(measurements: pd.DataFrame) -> Dict[str, Any]:
 
     return dict(values=values.tolist(),
                 column=create_node(data['col'], list(measurements)),
-                row=create_node(data['row'], list(measurements.index)))
+                row=create_node(data['row'], list(measurements.index)),
+                original={'columns': measurements.columns.tolist(),
+                          'rows': measurements.index.tolist(),
+                          'values': measurements.values.tolist()})
 
 
 def pairwise_correlation(measurements: pd.DataFrame, min_correlation: float = 0,

--- a/web/src/components/vis/Heatmap.vue
+++ b/web/src/components/vis/Heatmap.vue
@@ -98,6 +98,10 @@ export default {
       type: Array,
       default: () => [],
     },
+    original: { // { columns: string[], rows: string[], values: number[][] }
+      type: Object,
+      default: () => {},
+    },
     cluster: {
       type: Boolean,
       default: true,
@@ -233,7 +237,8 @@ export default {
     columnLeavesOriginal() {
       const {
         columnLeavesSorted,
-        columnClustering,
+        original,
+        transposed,
       } = this;
 
       // Make a lookup table of the leaves by leaf name.
@@ -243,7 +248,8 @@ export default {
       });
 
       // Reorder the leaves by the order given in the clustering prop.
-      return columnClustering.names.map(name => lookup.get(name));
+      const source = transposed ? original.rows : original.columns;
+      return source.map(name => lookup.get(name));
     },
 
     rowLeaves() {
@@ -257,7 +263,8 @@ export default {
     rowLeavesOriginal() {
       const {
         rowLeavesSorted,
-        rowClustering,
+        original,
+        transposed,
       } = this;
 
       // Make a lookup table of the leaves by leaf name.
@@ -267,7 +274,8 @@ export default {
       });
 
       // Reorder the leaves by the order given in the clustering prop.
-      return rowClustering.names.map(name => lookup.get(name));
+      const source = transposed ? original.columns : original.rows;
+      return source.map(name => lookup.get(name));
     },
 
     columnDendrogramHeight() {

--- a/web/src/components/vis/Heatmap.vue
+++ b/web/src/components/vis/Heatmap.vue
@@ -243,7 +243,7 @@ export default {
       });
 
       // Reorder the leaves by the order given in the clustering prop.
-      return columnClustering.names.map((name) => lookup.get(name));
+      return columnClustering.names.map(name => lookup.get(name));
     },
 
     rowLeaves() {
@@ -267,7 +267,7 @@ export default {
       });
 
       // Reorder the leaves by the order given in the clustering prop.
-      return rowClustering.names.map((name) => lookup.get(name));
+      return rowClustering.names.map(name => lookup.get(name));
     },
 
     columnDendrogramHeight() {

--- a/web/src/components/vis/Heatmap.vue
+++ b/web/src/components/vis/Heatmap.vue
@@ -98,6 +98,10 @@ export default {
       type: Array,
       default: () => [],
     },
+    cluster: {
+      type: Boolean,
+      default: true,
+    },
     columnClustering: { // ITreeNode
       type: Object,
       default: null,
@@ -217,12 +221,55 @@ export default {
     legendDomain() {
       return this.valueScale.domain().map(this.format);
     },
+
     columnLeaves() {
+      return this.cluster ? this.columnLeavesSorted : this.columnLeavesOriginal;
+    },
+
+    columnLeavesSorted() {
       return this.columnTree ? this.columnTree.leaves() : [];
     },
+
+    columnLeavesOriginal() {
+      const {
+        columnLeavesSorted,
+        columnClustering,
+      } = this;
+
+      // Make a lookup table of the leaves by leaf name.
+      const lookup = new Map();
+      columnLeavesSorted.forEach((leaf) => {
+        lookup.set(leaf.data.name, leaf);
+      });
+
+      // Reorder the leaves by the order given in the clustering prop.
+      return columnClustering.names.map((name) => lookup.get(name));
+    },
+
     rowLeaves() {
+      return this.cluster ? this.rowLeavesSorted : this.rowLeavesOriginal;
+    },
+
+    rowLeavesSorted() {
       return this.rowTree ? this.rowTree.leaves() : [];
     },
+
+    rowLeavesOriginal() {
+      const {
+        rowLeavesSorted,
+        rowClustering,
+      } = this;
+
+      // Make a lookup table of the leaves by leaf name.
+      const lookup = new Map();
+      rowLeavesSorted.forEach((leaf) => {
+        lookup.set(leaf.data.name, leaf);
+      });
+
+      // Reorder the leaves by the order given in the clustering prop.
+      return rowClustering.names.map((name) => lookup.get(name));
+    },
+
     columnDendogramHeight() {
       return this.columnConfig.dendogram ? this.height * DENDOGRAM_RATIO : 0;
     },

--- a/web/src/components/vis/Heatmap.vue
+++ b/web/src/components/vis/Heatmap.vue
@@ -102,10 +102,6 @@ export default {
       type: Object,
       default: () => {},
     },
-    cluster: {
-      type: Boolean,
-      default: true,
-    },
     columnClustering: { // ITreeNode
       type: Object,
       default: null,
@@ -227,7 +223,7 @@ export default {
     },
 
     columnLeaves() {
-      return this.cluster ? this.columnLeavesSorted : this.columnLeavesOriginal;
+      return this.columnConfig.dendrogram ? this.columnLeavesSorted : this.columnLeavesOriginal;
     },
 
     columnLeavesSorted() {
@@ -253,7 +249,7 @@ export default {
     },
 
     rowLeaves() {
-      return this.cluster ? this.rowLeavesSorted : this.rowLeavesOriginal;
+      return this.rowConfig.dendrogram ? this.rowLeavesSorted : this.rowLeavesOriginal;
     },
 
     rowLeavesSorted() {

--- a/web/src/components/vis/Heatmap.vue
+++ b/web/src/components/vis/Heatmap.vue
@@ -44,7 +44,7 @@ function aggregate(arr, rs, cs, transposed) {
   return sum / l;
 }
 
-const DENDOGRAM_RATIO = 0.2;
+const DENDROGRAM_RATIO = 0.2;
 const LABEL_WIDTH = 150;
 
 const MDI_PLUS_CIRCLE = '\uF417;';
@@ -110,15 +110,15 @@ export default {
       type: Object,
       default: null,
     },
-    rowConfig: { // { dendogram: boolean, colorer?: (name) => string }
+    rowConfig: { // { dendrogram: boolean, colorer?: (name) => string }
       type: Object,
-      default: () => ({ dendogram: true, colorer: null }),
+      default: () => ({ dendrogram: true, colorer: null }),
     },
-    columnConfig: { // { dendogram: boolean, colorer?: (name) => string }
+    columnConfig: { // { dendrogram: boolean, colorer?: (name) => string }
       type: Object,
-      default: () => ({ dendogram: true, colorer: null }),
+      default: () => ({ dendrogram: true, colorer: null }),
     },
-    layout: { // { dendogram: boolean }
+    layout: { // { dendrogram: boolean }
       type: String,
       validate: v => heatmapLayouts.find(d => d.value === v),
       default: heatmapLayouts[0].value,
@@ -147,7 +147,7 @@ export default {
         collapsed: new Set(),
         focus: null,
       },
-      DENDOGRAM_RATIO,
+      DENDROGRAM_RATIO,
       LABEL_WIDTH,
     };
   },
@@ -270,15 +270,15 @@ export default {
       return rowClustering.names.map((name) => lookup.get(name));
     },
 
-    columnDendogramHeight() {
-      return this.columnConfig.dendogram ? this.height * DENDOGRAM_RATIO : 0;
+    columnDendrogramHeight() {
+      return this.columnConfig.dendrogram ? this.height * DENDROGRAM_RATIO : 0;
     },
-    rowDendogramWidth() {
-      return this.rowConfig.dendogram ? this.width * DENDOGRAM_RATIO : 0;
+    rowDendrogramWidth() {
+      return this.rowConfig.dendrogram ? this.width * DENDROGRAM_RATIO : 0;
     },
     matrixDimensions() {
-      let width = this.width - this.rowDendogramWidth - LABEL_WIDTH;
-      let height = this.height - this.columnDendogramHeight - LABEL_WIDTH;
+      let width = this.width - this.rowDendrogramWidth - LABEL_WIDTH;
+      let height = this.height - this.columnDendrogramHeight - LABEL_WIDTH;
       if (this.layout === 'squareCells') {
         const wx = width / this.columnLeaves.length;
         const hy = height / this.rowLeaves.length;
@@ -348,12 +348,12 @@ export default {
         return null;
       }
       const l = cluster()
-        .size([layoutWidth, layoutHeight * DENDOGRAM_RATIO - this.padding2])
+        .size([layoutWidth, layoutHeight * DENDROGRAM_RATIO - this.padding2])
         .separation(() => 1);
       return l(root);
     },
     updateTree(ref, root, wrapper, config, horizontalLayout) {
-      if (!ref || !config.dendogram || !root) {
+      if (!ref || !config.dendrogram || !root) {
         return;
       }
       const svg = select(ref);
@@ -422,14 +422,14 @@ export default {
       inner.attr('transform', d => `translate(${d.x},${d.y})`);
     },
     updateColumn() {
-      if (this.columnDendogramHeight === 0) {
+      if (this.columnDendrogramHeight === 0) {
         return;
       }
       this.updateTree(this.$refs.column, this.columnHierarchy, this.column,
         this.columnConfig, true);
     },
     updateRow() {
-      if (this.rowDendogramWidth === 0) {
+      if (this.rowDendrogramWidth === 0) {
         return;
       }
       this.updateTree(this.$refs.row, this.rowHierarchy, this.row, this.rowConfig, false);
@@ -563,40 +563,40 @@ export default {
 
     generateImage() {
       const canvas = document.createElement('canvas');
-      const columnDendogram = this.columnConfig.dendogram ? this.height * DENDOGRAM_RATIO : 0;
-      const rowDendogram = this.rowConfig.dendogram ? this.width * DENDOGRAM_RATIO : 0;
+      const columnDendrogram = this.columnConfig.dendrogram ? this.height * DENDROGRAM_RATIO : 0;
+      const rowDendrogram = this.rowConfig.dendrogram ? this.width * DENDROGRAM_RATIO : 0;
 
-      canvas.width = rowDendogram + this.matrixWidth + LABEL_WIDTH;
-      canvas.height = columnDendogram + this.matrixHeight + LABEL_WIDTH;
+      canvas.width = rowDendrogram + this.matrixWidth + LABEL_WIDTH;
+      canvas.height = columnDendrogram + this.matrixHeight + LABEL_WIDTH;
 
       const ctx = canvas.getContext('2d');
       // copy matrix first
       ctx.fillStyle = 'white';
       ctx.fillRect(0, 0, canvas.width, canvas.height);
-      ctx.drawImage(this.$refs.matrix, rowDendogram, columnDendogram);
+      ctx.drawImage(this.$refs.matrix, rowDendrogram, columnDendrogram);
 
       const toWait = [];
 
-      if (columnDendogram > 0) {
-        // column dendogram
+      if (columnDendrogram > 0) {
+        // column dendrogram
         const url = svg2url(this.$refs.column, { font: false, icons: true });
-        const img = new Image(this.width * DENDOGRAM_RATIO, this.matrixHeight);
+        const img = new Image(this.width * DENDROGRAM_RATIO, this.matrixHeight);
         toWait.push(new Promise((resolve) => {
           img.onload = () => {
-            ctx.drawImage(img, rowDendogram, 0);
+            ctx.drawImage(img, rowDendrogram, 0);
             URL.revokeObjectURL(url);
             resolve();
           };
           img.src = url;
         }));
       }
-      if (rowDendogram > 0) {
-        // row dendogram
+      if (rowDendrogram > 0) {
+        // row dendrogram
         const url = svg2url(this.$refs.row, { font: false, icons: true });
-        const img = new Image(this.matrixWidth, this.height * DENDOGRAM_RATIO);
+        const img = new Image(this.matrixWidth, this.height * DENDROGRAM_RATIO);
         toWait.push(new Promise((resolve) => {
           img.onload = () => {
-            ctx.drawImage(img, 0, columnDendogram);
+            ctx.drawImage(img, 0, columnDendrogram);
             URL.revokeObjectURL(url);
             resolve();
           };
@@ -607,7 +607,7 @@ export default {
       // row labels
       {
         ctx.save();
-        ctx.translate(rowDendogram + this.matrixWidth, columnDendogram);
+        ctx.translate(rowDendrogram + this.matrixWidth, columnDendrogram);
         const hi = this.matrixHeight / this.rowLeaves.length;
         const { colorer } = this.rowConfig;
         if (colorer) {
@@ -630,7 +630,7 @@ export default {
       // column labels
       {
         ctx.save();
-        ctx.translate(rowDendogram, columnDendogram + this.matrixHeight);
+        ctx.translate(rowDendrogram, columnDendrogram + this.matrixHeight);
         const wi = this.matrixWidth / this.columnLeaves.length;
         const { colorer } = this.columnConfig;
         if (colorer) {
@@ -662,14 +662,14 @@ export default {
 
 <template lang="pug">
 .grid(v-resize:throttle="onResize")
-  svg.column(ref="column", v-show="columnConfig.dendogram",
+  svg.column(ref="column", v-show="columnConfig.dendrogram",
       :width="matrixWidth",
-      :height="height * DENDOGRAM_RATIO", xmlns="http://www.w3.org/2000/svg",
+      :height="height * DENDROGRAM_RATIO", xmlns="http://www.w3.org/2000/svg",
       :data-update="reactiveColumnUpdate")
     g.edges(:transform="`translate(0,${padding})`")
     g.nodes(:transform="`translate(0,${padding})`")
-  svg.row(ref="row", v-show="rowConfig.dendogram",
-      :width="width * DENDOGRAM_RATIO",
+  svg.row(ref="row", v-show="rowConfig.dendrogram",
+      :width="width * DENDROGRAM_RATIO",
       :height="matrixHeight", xmlns="http://www.w3.org/2000/svg",
       :data-update="reactiveRowUpdate")
     g.edges(:transform="`translate(${padding},0)`")
@@ -682,7 +682,7 @@ export default {
   .rowlabel(ref="rowlabel",
       :style="{fontSize: fontSize+'px', width: LABEL_WIDTH+'px', height: this.matrixHeight+'px'}",
       :data-update="reactiveRowLabelUpdate")
-  .legend-wrapper(v-show="columnConfig.dendogram && rowConfig.dendogram")
+  .legend-wrapper(v-show="columnConfig.dendrogram && rowConfig.dendrogram")
     .legend(:data-from="legendDomain[0]", :data-to="legendDomain[1]",
         :style="{background: legendGradient}")
 </template>

--- a/web/src/components/vis/HeatmapTile.vue
+++ b/web/src/components/vis/HeatmapTile.vue
@@ -127,7 +127,7 @@ vis-tile-large(v-if="plot", title="Heatmap", expanded, download, :download-impl=
     sample-colorer(:dataset="dataset", v-model="sampleColor")
 
     v-toolbar.darken-3(color="primary", dark, flat, dense)
-      v-toolbar-title.switch-title Dendrogram
+      v-toolbar-title Dendrogram
     v-card.mx-3(flat)
       v-card-actions(:style="{display: 'block'}")
         v-checkbox.my-0(
@@ -151,17 +151,3 @@ vis-tile-large(v-if="plot", title="Heatmap", expanded, download, :download-impl=
       :row-clustering="plot.data ? plot.data.column : null",
       :column-clustering="plot.data ? plot.data.row : null")
 </template>
-
-<style lang="scss" scoped>
-.switch-title {
-  align-items: center;
-  display: flex;
-  justify-content: space-between;
-  overflow: visible;
-  width: 100%;
-  .switch {
-    flex-grow: 0;
-    margin-right: -10px;
-  }
-}
-</style>

--- a/web/src/components/vis/HeatmapTile.vue
+++ b/web/src/components/vis/HeatmapTile.vue
@@ -33,7 +33,6 @@ export default {
   data() {
     return {
       colors,
-      cluster: true,
       row: {
         dendrogram: true,
         colorer: this.columnColor,
@@ -71,12 +70,6 @@ export default {
     },
   },
   watch: {
-    cluster() {
-      if (!this.cluster) {
-        this.row.dendrogram = false;
-        this.column.dendrogram = false;
-      }
-    },
     metaboliteFilter(newValue) {
       if (newValue && newValue.option) {
         this.changePlotArgs({
@@ -135,26 +128,22 @@ vis-tile-large(v-if="plot", title="Heatmap", expanded, download, :download-impl=
 
     v-toolbar.darken-3(color="primary", dark, flat, dense)
       v-toolbar-title.switch-title Dendrogram
-        v-switch.switch(v-model="cluster", hide-details)
     v-card.mx-3(flat)
       v-card-actions(:style="{display: 'block'}")
         v-checkbox.my-0(
             v-model="row.dendrogram",
             label="Metabolite",
-            hide-details,
-            :disabled="!cluster")
+            hide-details)
         v-checkbox.my-0(
             v-model="column.dendrogram",
             label="Sample",
-            hide-details,
-            :disabled="!cluster")
+            hide-details)
     toolbar-option(title="Layout", :value="layout",
         :options="layouts",
         @change="layout = $event")
 
   heatmap(ref="heatmap",
       v-if="plot && plot.data && dataset.ready && values",
-      :cluster="cluster",
       :values="values",
       :original="original",
       transposed,

--- a/web/src/components/vis/HeatmapTile.vue
+++ b/web/src/components/vis/HeatmapTile.vue
@@ -64,7 +64,8 @@ export default {
   watch: {
     cluster() {
       if (!this.cluster) {
-        this.row.dendrogram = this.column.dendrogram = false;
+        this.row.dendrogram = false;
+        this.column.dendrogram = false;
       }
     },
     metaboliteFilter(newValue) {
@@ -128,8 +129,16 @@ vis-tile-large(v-if="plot", title="Heatmap", expanded, download, :download-impl=
         v-switch.switch(v-model="cluster", hide-details)
     v-card.mx-3(flat)
       v-card-actions(:style="{display: 'block'}")
-        v-checkbox.my-0(v-model="row.dendrogram", label="Metabolite", hide-details, :disabled="!cluster")
-        v-checkbox.my-0(v-model="column.dendrogram", label="Sample", hide-details, :disabled="!cluster")
+        v-checkbox.my-0(
+            v-model="row.dendrogram",
+            label="Metabolite",
+            hide-details,
+            :disabled="!cluster")
+        v-checkbox.my-0(
+            v-model="column.dendrogram",
+            label="Sample",
+            hide-details,
+            :disabled="!cluster")
     toolbar-option(title="Layout", :value="layout",
         :options="layouts",
         @change="layout = $event")

--- a/web/src/components/vis/HeatmapTile.vue
+++ b/web/src/components/vis/HeatmapTile.vue
@@ -33,6 +33,7 @@ export default {
   data() {
     return {
       colors,
+      cluster: true,
       row: {
         dendogram: true,
         colorer: this.columnColor,
@@ -61,6 +62,11 @@ export default {
     },
   },
   watch: {
+    cluster() {
+      if (!this.cluster) {
+        this.row.dendogram = this.column.dendogram = false;
+      }
+    },
     metaboliteFilter(newValue) {
       if (newValue && newValue.option) {
         this.changePlotArgs({
@@ -118,19 +124,35 @@ vis-tile-large(v-if="plot", title="Heatmap", expanded, download, :download-impl=
     sample-colorer(:dataset="dataset", v-model="sampleColor")
 
     v-toolbar.darken-3(color="primary", dark, flat, dense)
-      v-toolbar-title Dendogram
+      v-toolbar-title.switch-title Dendogram
+        v-switch.switch(v-model="cluster", hide-details)
     v-card.mx-3(flat)
       v-card-actions(:style="{display: 'block'}")
-        v-checkbox.my-0(v-model="row.dendogram", label="Metabolite", hide-details)
-        v-checkbox.my-0(v-model="column.dendogram", label="Sample", hide-details)
+        v-checkbox.my-0(v-model="row.dendogram", label="Metabolite", hide-details, :disabled="!cluster")
+        v-checkbox.my-0(v-model="column.dendogram", label="Sample", hide-details, :disabled="!cluster")
     toolbar-option(title="Layout", :value="layout",
         :options="layouts",
         @change="layout = $event")
 
   heatmap(ref="heatmap",
       v-if="plot && plot.data && dataset.ready && values",
+      :cluster="cluster",
       :values="values", transposed,
       :column-config="column", :row-config="row", :layout="layout",
       :row-clustering="plot.data ? plot.data.column : null",
       :column-clustering="plot.data ? plot.data.row : null")
 </template>
+
+<style lang="scss" scoped>
+.switch-title {
+  align-items: center;
+  display: flex;
+  justify-content: space-between;
+  overflow: visible;
+  width: 100%;
+  .switch {
+    flex-grow: 0;
+    margin-right: -10px;
+  }
+}
+</style>

--- a/web/src/components/vis/HeatmapTile.vue
+++ b/web/src/components/vis/HeatmapTile.vue
@@ -57,8 +57,17 @@ export default {
       if (!this.plot.data) {
         return [];
       }
+
       // TODO swap
       return this.plot.data ? this.plot.data.values : [];
+    },
+
+    original() {
+      if (!this.plot.data) {
+        return {};
+      }
+
+      return this.plot.data ? this.plot.data.original : {};
     },
   },
   watch: {
@@ -146,7 +155,9 @@ vis-tile-large(v-if="plot", title="Heatmap", expanded, download, :download-impl=
   heatmap(ref="heatmap",
       v-if="plot && plot.data && dataset.ready && values",
       :cluster="cluster",
-      :values="values", transposed,
+      :values="values",
+      :original="original",
+      transposed,
       :column-config="column", :row-config="row", :layout="layout",
       :row-clustering="plot.data ? plot.data.column : null",
       :column-clustering="plot.data ? plot.data.row : null")

--- a/web/src/components/vis/HeatmapTile.vue
+++ b/web/src/components/vis/HeatmapTile.vue
@@ -35,11 +35,11 @@ export default {
       colors,
       cluster: true,
       row: {
-        dendogram: true,
+        dendrogram: true,
         colorer: this.columnColor,
       },
       column: {
-        dendogram: true,
+        dendrogram: true,
         colorer: this.rowColor,
       },
       dummy: false,
@@ -64,7 +64,7 @@ export default {
   watch: {
     cluster() {
       if (!this.cluster) {
-        this.row.dendogram = this.column.dendogram = false;
+        this.row.dendrogram = this.column.dendrogram = false;
       }
     },
     metaboliteFilter(newValue) {
@@ -124,12 +124,12 @@ vis-tile-large(v-if="plot", title="Heatmap", expanded, download, :download-impl=
     sample-colorer(:dataset="dataset", v-model="sampleColor")
 
     v-toolbar.darken-3(color="primary", dark, flat, dense)
-      v-toolbar-title.switch-title Dendogram
+      v-toolbar-title.switch-title Dendrogram
         v-switch.switch(v-model="cluster", hide-details)
     v-card.mx-3(flat)
       v-card-actions(:style="{display: 'block'}")
-        v-checkbox.my-0(v-model="row.dendogram", label="Metabolite", hide-details, :disabled="!cluster")
-        v-checkbox.my-0(v-model="column.dendogram", label="Sample", hide-details, :disabled="!cluster")
+        v-checkbox.my-0(v-model="row.dendrogram", label="Metabolite", hide-details, :disabled="!cluster")
+        v-checkbox.my-0(v-model="column.dendrogram", label="Sample", hide-details, :disabled="!cluster")
     toolbar-option(title="Layout", :value="layout",
         :options="layouts",
         @change="layout = $event")


### PR DESCRIPTION
This adds a switch to the "Dendrogram" control panel in the heatmap tile, which will use the original order of the metabolites in the heatmap. This was requested by Tom, as sometimes the original order is meaningful on its own. Previously, the presence of the dendrogram meant that clustering was always performed and this original ordering was lost.