### PR TITLE
Filter out NaN values in analysis methods

### DIFF
--- a/viime/analyses.py
+++ b/viime/analyses.py
@@ -9,7 +9,7 @@ from .opencpu import opencpu_request
 
 
 def clean(df: pd.DataFrame) -> pd.DataFrame:
-    return df.replace([np.nan, np.Inf, -np.Inf], [None, None, None])
+    return df.fillna('NaN').replace([np.Inf, -np.Inf], ['Inf', '-Inf'])
 
 
 def wilcoxon_test(measurements: pd.DataFrame, groups: pd.Series,


### PR DESCRIPTION
Strangely, the json serializer used in python will encode invalid floating point values as `NaN`, `infinity`, etc.  But the javascript parser, will detect it as invalid json, and deserialize the entire object all `null`.

This was attempted to be handled in the code, but for whatever reason, didn't actually work.  In this change, we replace the invalid numeric value as a string description which is shown in its place.

Fixes #512