### PR TITLE
Fix transforms containing NaN's

### DIFF
--- a/viime/analyses.py
+++ b/viime/analyses.py
@@ -2,14 +2,10 @@ from io import StringIO
 from itertools import combinations
 from typing import Any, Dict, Optional
 
-import numpy as np
 import pandas as pd
 
+from .models import clean
 from .opencpu import opencpu_request
-
-
-def clean(df: pd.DataFrame) -> pd.DataFrame:
-    return df.fillna('NaN').replace([np.Inf, -np.Inf], ['Inf', '-Inf'])
 
 
 def wilcoxon_test(measurements: pd.DataFrame, groups: pd.Series,

--- a/viime/models.py
+++ b/viime/models.py
@@ -51,6 +51,11 @@ AXIS_NAME_TYPES = AxisNameTypes('row', 'column')
 METADATA_TYPES = MetaDataTypes('categorical', 'numerical', 'ordinal')
 
 
+def clean(df: pandas.DataFrame) -> pandas.DataFrame:
+    return df.fillna('NaN') \
+        .replace([numpy.Inf, -numpy.Inf], ['Inf', '-Inf'])
+
+
 def _guess_table_structure(table):
     # TODO: Implement this for real, this is just a dumb placeholder
     rows = [TABLE_ROW_TYPES.INDEX] + [
@@ -384,7 +389,7 @@ class CSVFileSchema(BaseSchema):
 
         data['table'] = data['table'].to_csv(header=False, index=False)
         if data.get('measurement_table') is not None:
-            data['measurement_table'] = data['measurement_table'].to_dict(
+            data['measurement_table'] = clean(data['measurement_table']).to_dict(
                 orient='split')
         return data
 
@@ -862,7 +867,7 @@ class ValidatedMetaboliteTableSchema(BaseSchema):
         # don't transfer columns or index depending on the type
         def convert(attr, *drop_columns):
             if attr in data:
-                converted = data[attr].to_dict(orient='split')
+                converted = clean(data[attr]).to_dict(orient='split')
                 for drop_column in drop_columns:
                     if drop_column in converted:
                         del converted[drop_column]

--- a/viime/transformation.py
+++ b/viime/transformation.py
@@ -4,6 +4,7 @@ TRANSFORMATION_METHODS = {'log10', 'squareroot', 'cuberoot', 'log2'}
 
 
 def transform(method, table):
+    table = table.astype(np.float64)
     if method is None:
         table = table
     elif method == 'log10':

--- a/viime/views.py
+++ b/viime/views.py
@@ -13,7 +13,7 @@ from werkzeug.datastructures import FileStorage
 from viime import opencpu, samples
 from viime.analyses import anova_test, hierarchical_clustering, pairwise_correlation, wilcoxon_test
 from viime.imputation import IMPUTE_MCAR_METHODS, IMPUTE_MNAR_METHODS
-from viime.models import AXIS_NAME_TYPES, CSVFile, CSVFileSchema, db, \
+from viime.models import AXIS_NAME_TYPES, clean, CSVFile, CSVFileSchema, db, \
     GroupLevelSchema, ModifyLabelListSchema, \
     TABLE_COLUMN_TYPES, TABLE_ROW_TYPES, \
     TableColumn, TableColumnSchema, TableRow, \
@@ -700,7 +700,7 @@ def _get_pca_data(validated_table):
     # insert per row label metadata information
     labels = validated_table.sample_metadata
     groups = validated_table.groups
-    data['labels'] = pandas.concat([groups, labels], axis=1).to_dict('list')
+    data['labels'] = clean(pandas.concat([groups, labels], axis=1)).to_dict('list')
     data['rows'] = table.index.tolist()
 
     return data


### PR DESCRIPTION
This fix to Tom's issue is on this [line](https://github.com/girder/viime/compare/fix-nan-transform?expand=1#diff-cec94bf766bacec39501f568e88150c5R7).  The `clip` operator when applied to an integer column was rounding to 0 rather than the intended 1e-8.

I also added the `clean` method to all places where we are serializing dataframes to dict's to avoid future instances of invalid json being passed to the client.