### PR TITLE
Fix race condition NPE

### DIFF
--- a/web/src/store/mutations.type.js
+++ b/web/src/store/mutations.type.js
@@ -1,3 +1,4 @@
+export const INTIALIZE_DATASET = 'initialize_dataset';
 export const REMOVE_DATASET = 'remove_dataset';
 export const SET_PLOT = 'set_plot';
 export const SET_SELECTION = 'set_selection';

--- a/web/src/utils/mixins.js
+++ b/web/src/utils/mixins.js
@@ -1,4 +1,5 @@
 import { LOAD_DATASET } from '../store/actions.type';
+import { INTIALIZE_DATASET } from '../store/mutations.type';
 
 /**
  * Load dataset from server for any view where
@@ -19,6 +20,8 @@ const loadDataset = {
   created() {
     const dataset = this.$store.getters.dataset(this.id);
     if (!dataset) {
+      // initialize the dataset to prevent NPE race conditions during slow loads
+      this.$store.commit(INTIALIZE_DATASET, { dataset_id: this.id });
       this.$store.dispatch(LOAD_DATASET, { dataset_id: this.id });
     }
   },


### PR DESCRIPTION
There is a race condition when loading the initial dataset using the
`LOAD_DATASET` action. Components will use the `loadDataset` mixin and
assume that the `dataset` in the store is non-null. `loadDataset`
triggers the `LOAD_DATASET` action, which asynchronously loads the
dataset. Normally this works fine, but during abnormally long loads or
unlucky scheduling `dataset` will be accessed before it is loaded,
resulting in an NPE in a random part of the app.

We already have an `INITIALIZE_DATASET` mutation that is used internally by `LOAD_DATASET`, so the solution is to
simply have the `loadDataset` mixin invoke it before triggering the
`LOAD_DATASET` action. Mutations are synchronous, so `dataset` is now
guaranteed to be initialized.