### PR TITLE
Clean up axisPlot reactivity

### DIFF
--- a/web/src/components/vis/LoadingsPlot.vue
+++ b/web/src/components/vis/LoadingsPlot.vue
@@ -1,7 +1,6 @@
 <template lang="pug">
 .main(v-resize:throttle="onResize")
-  svg(ref="svg", :width="width", :height="height", xmlns="http://www.w3.org/2000/svg",
-      :data-update="reactiveUpdate")
+  svg(ref="svg", :width="width", :height="height", xmlns="http://www.w3.org/2000/svg")
     g.master
       g.axes
       g.label.x(style="opacity: 0")
@@ -121,6 +120,20 @@ export default {
     },
     yrange() {
       return this.pcRange;
+    },
+  },
+  watch: {
+    points() {
+      this.update();
+    },
+    pcX() {
+      this.update();
+    },
+    pcY() {
+      this.update();
+    },
+    showCrosshairs() {
+      this.update();
     },
   },
   methods: {

--- a/web/src/components/vis/PcaPage/PcaPage.vue
+++ b/web/src/components/vis/PcaPage/PcaPage.vue
@@ -26,6 +26,9 @@ export default {
       pcXval: '1',
       pcYval: '2',
       numComponentsVal: '10',
+      pcX: 1,
+      pcY: 2,
+      numComponents: 10,
       showEllipses: true,
       showCrosshairs: true,
       showCutoffs: true,
@@ -36,23 +39,43 @@ export default {
   },
 
   computed: {
-    pcX() {
-      return Number.parseInt(this.pcXval, 10);
-    },
-
-    pcY() {
-      return Number.parseInt(this.pcYval, 10);
-    },
-
-    numComponents() {
-      return Number.parseInt(this.numComponentsVal, 10);
-    },
-
     ready() {
       const pcaReady = this.$store.getters.ready(this.id, 'pca');
       const loadingsReady = this.$store.getters.ready(this.id, 'loadings');
 
       return pcaReady && loadingsReady;
+    },
+  },
+  watch: {
+    pcXval: {
+      handler(val) {
+        const pcX = Number.parseInt(val, 10);
+        // eslint-disable-next-line no-restricted-globals
+        if (!isNaN(pcX)) {
+          this.pcX = pcX;
+        }
+      },
+      immediate: true,
+    },
+    pcYval: {
+      handler(val) {
+        const pcY = Number.parseInt(val, 10);
+        // eslint-disable-next-line no-restricted-globals
+        if (!isNaN(pcY)) {
+          this.pcY = pcY;
+        }
+      },
+      immediate: true,
+    },
+    numComponentsVal: {
+      handler(val) {
+        const numComponents = Number.parseInt(val, 10);
+        // eslint-disable-next-line no-restricted-globals
+        if (!isNaN(numComponents)) {
+          this.numComponents = numComponents;
+        }
+      },
+      immediate: true,
     },
   },
 };

--- a/web/src/components/vis/PcaPage/PcaPage.vue
+++ b/web/src/components/vis/PcaPage/PcaPage.vue
@@ -26,9 +26,6 @@ export default {
       pcXval: '1',
       pcYval: '2',
       numComponentsVal: '10',
-      pcX: 1,
-      pcY: 2,
-      numComponents: 10,
       showEllipses: true,
       showCrosshairs: true,
       showCutoffs: true,
@@ -39,43 +36,23 @@ export default {
   },
 
   computed: {
+    pcX() {
+      return Number.parseInt(this.pcXval, 10);
+    },
+
+    pcY() {
+      return Number.parseInt(this.pcYval, 10);
+    },
+
+    numComponents() {
+      return Number.parseInt(this.numComponentsVal, 10);
+    },
+
     ready() {
       const pcaReady = this.$store.getters.ready(this.id, 'pca');
       const loadingsReady = this.$store.getters.ready(this.id, 'loadings');
 
       return pcaReady && loadingsReady;
-    },
-  },
-  watch: {
-    pcXval: {
-      handler(val) {
-        const pcX = Number.parseInt(val, 10);
-        // eslint-disable-next-line no-restricted-globals
-        if (!isNaN(pcX)) {
-          this.pcX = pcX;
-        }
-      },
-      immediate: true,
-    },
-    pcYval: {
-      handler(val) {
-        const pcY = Number.parseInt(val, 10);
-        // eslint-disable-next-line no-restricted-globals
-        if (!isNaN(pcY)) {
-          this.pcY = pcY;
-        }
-      },
-      immediate: true,
-    },
-    numComponentsVal: {
-      handler(val) {
-        const numComponents = Number.parseInt(val, 10);
-        // eslint-disable-next-line no-restricted-globals
-        if (!isNaN(numComponents)) {
-          this.numComponents = numComponents;
-        }
-      },
-      immediate: true,
     },
   },
 };

--- a/web/src/components/vis/ScreePlot.vue
+++ b/web/src/components/vis/ScreePlot.vue
@@ -1,7 +1,6 @@
 <template lang="pug">
 .main(v-resize:throttle="onResize")
-  svg(ref="svg", :width="width", :height="height", xmlns="http://www.w3.org/2000/svg",
-      :data-update="reactiveUpdate")
+  svg(ref="svg", :width="width", :height="height", xmlns="http://www.w3.org/2000/svg")
     g.master
       g.axes
       g.label.x
@@ -158,6 +157,17 @@ export default {
       return result;
     },
 
+  },
+  watch: {
+    eigenvalues() {
+      this.update();
+    },
+    numComponents() {
+      this.update();
+    },
+    showCutoffs() {
+      this.update();
+    },
   },
   methods: {
     update() {

--- a/web/src/components/vis/VolcanoPlot.vue
+++ b/web/src/components/vis/VolcanoPlot.vue
@@ -66,9 +66,11 @@ export default {
       this.update();
     },
   },
+  mounted() {
+    this.update();
+  },
   methods: {
     update() {
-      //
       // Compute the total variance in all the PCs.
       const svg = select(this.$refs.svg);
       this.axisPlot(svg);

--- a/web/src/components/vis/analyses.js
+++ b/web/src/components/vis/analyses.js
@@ -84,7 +84,7 @@ export default [
     icon: vuetify.icons.metaboliteTable,
   },
   {
-    path: 'wilcoxon_volacno',
+    path: 'wilcoxon_volcano',
     name: 'Wilcoxon test (Volcano Plot)',
     shortName: 'Wilcoxon Volcano Plot',
     description() {

--- a/web/src/components/vis/mixins/axisPlot.js
+++ b/web/src/components/vis/mixins/axisPlot.js
@@ -27,19 +27,9 @@ export const axisPlot = {
       svg: null,
       width: 100,
       height: 100,
-      refsMounted: false, // to force an rendering after mounting
     };
   },
   computed: {
-    reactiveUpdate() {
-      if (!this.refsMounted) {
-        return '';
-      }
-      if (this.$refs.svg) {
-        this.update();
-      }
-      return '';
-    },
     dwidth() {
       const { width, margin } = this;
       return width - margin.left - margin.right;
@@ -77,12 +67,9 @@ export const axisPlot = {
     axisY() {
       return axisLeft(this.scaleY);
     },
-
   },
   mounted() {
     this.onResize();
-    this.refsMounted = true;
-    this.update();
   },
   methods: {
     axisPlot(svg) {


### PR DESCRIPTION
Components which used `axisPlot` were relying on an awkward misuse of
computed properties to trigger a render immediately after rendering the
first time. I think the original motivation was that the graph SVG
element was not mounted until after the first render. However this is
trivially solved by calling the `update` function which updates the SVG
in a `mounted` hook.

- Remove the `reactiveUpdate` component from all plots which use it
- Fix a bug where putting "" into an integer field breaks the PCA plot
- Fix a path typo (`wilcoxon_volacno`)