### PR TITLE
Validate normalization errors with non-numeric data

### DIFF
--- a/viime/normalization.py
+++ b/viime/normalization.py
@@ -4,6 +4,7 @@ from marshmallow import ValidationError
 import pandas as pd
 from sklearn import preprocessing
 
+
 NORMALIZATION_METHODS = {'minmax', 'sum', 'reference-sample', 'weight-volume'}
 
 
@@ -47,4 +48,6 @@ def reference_sample(table: pd.DataFrame, argument) -> pd.DataFrame:
 
 
 def weight_volume(table: pd.DataFrame, argument, sample_metadata: pd.DataFrame):
+    if sample_metadata.dtypes[argument].name != 'float64':
+        raise ValidationError('Column contains non-numeric data')
     return 100 * table.div(sample_metadata.loc[:, argument], axis=0)

--- a/viime/views.py
+++ b/viime/views.py
@@ -580,6 +580,8 @@ def save_validated_csv_file(csv_id: str):
 def serialize_validated_table(validated_table: ValidatedMetaboliteTable):
     try:
         return validated_metabolite_table_schema.dump(validated_table)
+    except ValidationError as ve:
+        raise ve
     except Exception as e:
         current_app.logger.exception(e)
         raise ValidationError('Error applying data transformation')


### PR DESCRIPTION
Fixes #165 
The `weight-volume` normalization method in the Transform table uses a
sample column to transform the values in the rest of the data. If that
column contains non-numeric data, the transform will fail and throw a
server error.

The solution is to validate that the selected column is strictly numeric
before normalizing, and throwing a validation error if it is not.

Sadly the client doesn't do any nice error handling on 400 validation errors, so the client side behavior is unchanged. This should fix the server error in sentry though.