### PR TITLE
Remove custom classes from pretreatment menu

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "e903293ee003e5346835e63803c8de87e7fb6538bced10ca93d263123157f3d0"
+            "sha256": "701eca715a8ed756d4ba4c863e64c4d5b18f739d34ea8fcf68e08beff08f44c6"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -25,10 +25,10 @@
         },
         "certifi": {
             "hashes": [
-                "sha256:1d987a998c75633c40847cc966fcf5904906c920a7f17ef374f5aa4282abd304",
-                "sha256:51fcb31174be6e6664c5f69e3e1691a2d72a1a12e90f872cbdb1567eb47b6519"
+                "sha256:5ad7e9a056d25ffa5082862e36f119f7f7cec6457fa07ee2f8c339814b80c9b1",
+                "sha256:9cd41137dc19af6a5e03b630eefe7d1f458d964d406342dd3edf625839b944cc"
             ],
-            "version": "==2020.4.5.1"
+            "version": "==2020.4.5.2"
         },
         "chardet": {
             "hashes": [
@@ -76,7 +76,6 @@
                 "sha256:72170423eb4612f0847318afff8c247b38bd516b7737adfc10d1c2cdbb382d16",
                 "sha256:f4d97201660e6bbcff2d89d082b5b6d31abee04b1b3003ee073a6fd25ad1d69a"
             ],
-            "index": "pypi",
             "version": "==3.0.8"
         },
         "flask-migrate": {

--- a/web/src/components/Pretreatment.vue
+++ b/web/src/components/Pretreatment.vue
@@ -79,52 +79,63 @@ v-layout.pretreatment-component(row, fill-height)
             :class="{ active: problemData.type === problem && dataset.id === id}",
             :inactive="!problemData.clickable",
             :key="problemData.title")
-          v-list-tile-title
+          v-list-tile-action
             v-icon.pr-1(
                 :color="problemData.severity") {{ $vuetify.icons[problemData.severity] }}
-            | {{ problemData.title }}
-            span(v-if="problemData.data") ({{ problemData.data.length }})
-            v-tooltip(v-else, top)
-              template(#activator="{ on }")
-                v-icon.pr-1(small, v-on="on") {{ $vuetify.icons.info }}
-              span {{ problemData.description }}
+          v-list-tile-content
+            v-list-tile-title
+              | {{ problemData.title }}
+              span(v-if="problemData.data") ({{ problemData.data.length }})
+              v-tooltip(v-else, top)
+                template(#activator="{ on }")
+                  v-icon.pr-1(small, v-on="on") {{ $vuetify.icons.info }}
+                span {{ problemData.description }}
 
         v-list-tile(:to="{ name: 'Impute Table', params: { id: dataset.id } }",
             v-show="!isMerged(dataset)")
-          v-list-tile-title
+          v-list-tile-action
             v-icon.pr-1 {{ $vuetify.icons.tableEdit }}
-            | Impute Table
+          v-list-tile-content
+            v-list-tile-title
+              | Impute Table
 
         v-list-tile(:to="{ name: 'Transform Table', params: { id: dataset.id } }",
             :disabled="!valid(dataset)", v-show="!isMerged(dataset)")
-          v-list-tile-title
+          v-list-tile-action
             v-icon.pr-1 {{ $vuetify.icons.bubbles }}
-            | Transform Table
-
-        v-list-group(
-            no-action,
-            sub-group,
-            :class="{ active: $route.name === 'Analyze Data' && dataset.id === id}")
-          template(#activator)
-            v-list-tile(
-                :to="{ name: 'Analyze Data', params: { id: dataset.id } }",
-                exact,
-                :disabled="!valid(dataset)")
-              v-list-tile-title
-                v-icon.pr-1 {{ $vuetify.icons.cogs }}
-                | Analyze Table
-          v-list-tile(v-for="a in analyses", :key="a.path",
-              :to="{ name: a.shortName, params: { id: dataset.id } }",
-              :disabled="!valid(dataset)")
+          v-list-tile-content
             v-list-tile-title
-              v-icon.pr-1(:style="a.iconStyle") {{ a.icon || $vuetify.icons.compare }}
-              | {{a.shortName}}
+              | Transform Table
+
+        v-list
+          v-list-group(
+              :class="{ active: $route.name === 'Analyze Data' && dataset.id === id}")
+            template(#activator)
+              v-list-tile(
+                  :to="{ name: 'Analyze Data', params: { id: dataset.id } }",
+                  exact,
+                  :disabled="!valid(dataset)")
+                v-list-tile-action
+                  v-icon.pr-1 {{ $vuetify.icons.cogs }}
+                v-list-tile-content
+                  v-list-tile-title
+                    | Analyze Table
+            v-list-tile(v-for="a in analyses", :key="a.path",
+                :to="{ name: a.shortName, params: { id: dataset.id } }",
+                :disabled="!valid(dataset)")
+              v-list-tile-action
+                v-icon.pr-1(:style="a.iconStyle") {{ a.icon || $vuetify.icons.compare }}
+              v-list-tile-content
+                v-list-tile-title
+                  | {{a.shortName}}
 
         v-list-tile(:to="{ name: 'Download Data', params: { id: dataset.id } }",
             :disabled="!valid(dataset)")
-          v-list-tile-title
+          v-list-tile-action
             v-icon.pr-1 {{ $vuetify.icons.fileDownload }}
-            | Download Data
+          v-list-tile-content
+            v-list-tile-title
+              | Download Data
 
   router-view
 </template>

--- a/web/src/components/Pretreatment.vue
+++ b/web/src/components/Pretreatment.vue
@@ -70,9 +70,11 @@ v-layout.pretreatment-component(row, fill-height)
                 | {{ $vuetify.icons.check }}
 
         v-list-tile(:to="{ name: 'Clean Up Table', params: { id: dataset.id } }", exact)
-          v-list-tile-title
+          v-list-tile-action
             v-icon {{ $vuetify.icons.tableEdit }}
-            | Clean Up Table
+          v-list-tile-content
+            v-list-tile-title
+              | Clean Up Table
 
         v-list-tile(v-for="problemData in dataset.validation",
             @click="problemNav(problemData)",

--- a/web/src/components/Pretreatment.vue
+++ b/web/src/components/Pretreatment.vue
@@ -50,7 +50,7 @@ v-layout.pretreatment-component(row, fill-height)
 
   v-navigation-drawer.navigation(floating, permanent, style="min-width: 220px; width: 220px;",
       touchless, disable-resize-watcher, stateless)
-    v-list(dense)
+    v-list.py-0(dense)
       v-list-group(
           v-for="(dataset, index) in datasets",
           :key="dataset.id",

--- a/web/src/components/Pretreatment.vue
+++ b/web/src/components/Pretreatment.vue
@@ -22,9 +22,6 @@ export default {
     };
   },
   methods: {
-    stopPropagation(evt) {
-      evt.stopPropagation();
-    },
     valid(dataset) {
       return this.$store.getters.valid(dataset.id);
     },
@@ -54,15 +51,17 @@ v-layout.pretreatment-component(row, fill-height)
 
   v-navigation-drawer.navigation(floating, permanent, style="min-width: 220px; width: 220px;",
       touchless, disable-resize-watcher, stateless)
-    v-list
-      v-list-group.root-level(v-for="(dataset, index) in datasets",
+    v-list(dense)
+      v-list-group(
+          v-for="(dataset, index) in datasets",
           :key="dataset.id",
           :class="{ active: $route.name === 'Pretreat Data' && dataset.id === id}",
           :value="dataset.id === id")
         template(#activator)
-          v-list-tile.dataset-level(:to="{ name: 'Pretreat Data', params: { id: dataset.id } }",
-              exact, @click="stopPropagation")
-            v-list-tile-title.title
+          v-list-tile.mr-0.pr-2(
+              :to="{ name: 'Pretreat Data', params: { id: dataset.id } }",
+              exact)
+            v-list-tile-title.body-2.grow
               | {{ dataset.name }}
             v-list-tile-action
               v-icon(color="warning", v-if="dataset.validation.length")
@@ -70,211 +69,62 @@ v-layout.pretreatment-component(row, fill-height)
               v-icon(color="success", v-else)
                 | {{ $vuetify.icons.check }}
 
-        v-list-tile.top-level(:to="{ name: 'Clean Up Table', params: { id: dataset.id } }", exact)
+        v-list-tile(:to="{ name: 'Clean Up Table', params: { id: dataset.id } }", exact)
           v-list-tile-title
-            v-icon.drawericon {{ $vuetify.icons.tableEdit }}
+            v-icon {{ $vuetify.icons.tableEdit }}
             | Clean Up Table
 
-        v-list-tile.sub-level(v-for="problemData in dataset.validation",
+        v-list-tile(v-for="problemData in dataset.validation",
             @click="problemNav(problemData)",
             :class="{ active: problemData.type === problem && dataset.id === id}",
             :inactive="!problemData.clickable",
             :key="problemData.title")
           v-list-tile-title
-            v-icon.drawericon(
+            v-icon.pr-1(
                 :color="problemData.severity") {{ $vuetify.icons[problemData.severity] }}
             | {{ problemData.title }}
             span(v-if="problemData.data") ({{ problemData.data.length }})
             v-tooltip(v-else, top)
               template(#activator="{ on }")
-                v-icon(small, @click="", v-on="on") {{ $vuetify.icons.info }}
+                v-icon.pr-1(small, v-on="on") {{ $vuetify.icons.info }}
               span {{ problemData.description }}
 
-        v-list-tile.sub-level(:to="{ name: 'Impute Table', params: { id: dataset.id } }",
+        v-list-tile(:to="{ name: 'Impute Table', params: { id: dataset.id } }",
             v-show="!isMerged(dataset)")
           v-list-tile-title
-            v-icon.drawericon {{ $vuetify.icons.tableEdit }}
+            v-icon.pr-1 {{ $vuetify.icons.tableEdit }}
             | Impute Table
 
-        v-list-tile.top-level(:to="{ name: 'Transform Table', params: { id: dataset.id } }",
+        v-list-tile(:to="{ name: 'Transform Table', params: { id: dataset.id } }",
             :disabled="!valid(dataset)", v-show="!isMerged(dataset)")
           v-list-tile-title
-            v-icon.pr-1.drawericon {{ $vuetify.icons.bubbles }}
+            v-icon.pr-1 {{ $vuetify.icons.bubbles }}
             | Transform Table
 
-        v-list-group.top-level(sub-group,
-            :class="{ active: $route.name === 'Analyze Data' && dataset.id === id}",
-            value="true")
+        v-list-group(
+            no-action,
+            sub-group,
+            :class="{ active: $route.name === 'Analyze Data' && dataset.id === id}")
           template(#activator)
-            v-list-tile.top-level(:to="{ name: 'Analyze Data', params: { id: dataset.id } }", exact,
-                :disabled="!valid(dataset)",
-                @click="stopPropagation")
+            v-list-tile(
+                :to="{ name: 'Analyze Data', params: { id: dataset.id } }",
+                exact,
+                :disabled="!valid(dataset)")
               v-list-tile-title
-                v-icon.drawericon {{ $vuetify.icons.cogs }}
+                v-icon.pr-1 {{ $vuetify.icons.cogs }}
                 | Analyze Table
-          v-list-tile.sub-level(v-for="a in analyses", :key="a.path",
+          v-list-tile(v-for="a in analyses", :key="a.path",
               :to="{ name: a.shortName, params: { id: dataset.id } }",
               :disabled="!valid(dataset)")
             v-list-tile-title
-              v-icon.drawericon(:style="a.iconStyle") {{ a.icon || $vuetify.icons.compare }}
+              v-icon.pr-1(:style="a.iconStyle") {{ a.icon || $vuetify.icons.compare }}
               | {{a.shortName}}
 
-        v-list-tile.top-level(:to="{ name: 'Download Data', params: { id: dataset.id } }",
+        v-list-tile(:to="{ name: 'Download Data', params: { id: dataset.id } }",
             :disabled="!valid(dataset)")
           v-list-tile-title
-            v-icon.pr-1.drawericon {{ $vuetify.icons.fileDownload }}
+            v-icon.pr-1 {{ $vuetify.icons.fileDownload }}
             | Download Data
 
   router-view
 </template>
-
-<style lang="scss">
-.navigation {
-  display: flex;
-  flex-direction: column;
-
-  > .v-list {
-    padding: 0;
-    flex: 1 1 0;
-    overflow: auto;
-
-    > .v-list__group > .v-list__group__items {
-      padding: 8px 0;
-    }
-  }
-
-  .v-list__group__header.v-list__group__header--sub-group
-    .v-list__group__header__prepend-icon .v-icon,
-  .v-list__group__header
-    .v-list__group__header__append-icon .v-icon {
-    transform: rotate(-90deg);
-  }
-  .v-list__group__header--active.v-list__group__header--sub-group
-    .v-list__group__header__prepend-icon .v-icon,
-  .v-list__group__header--active
-    .v-list__group__header__append-icon .v-icon {
-    transform: unset;
-  }
-
-  .drawericon {
-    vertical-align: top;
-    margin-right: 4px;
-  }
-
-  .root-level > .v-list__group__header--active {
-    background: unset;
-  }
-
-  .root-level.active > .v-list__group__header {
-    background-color: #37474f;
-  }
-
-  .root-level.active > .v-list__group__header,
-  .top-level.active > .v-list__group__header {
-    .v-list__group__header__prepend-icon > .v-icon,
-    .v-list__group__header__append-icon > .v-icon,
-    .v-list__tile__title {
-      color: white !important;
-    }
-  }
-
-  .dataset-level {
-    order: 2;
-
-    .v-list__tile {
-      padding: 0 8px 0 0;
-      color: black !important;
-
-      &:hover {
-        background: unset;
-      }
-    }
-
-    .v-list__tile__action {
-      min-width: unset;
-    }
-  }
-
-  .top-level {
-    .v-list__group__header {
-      position: relative;
-
-      &:hover {
-        background: unset;
-      }
-
-      .v-list__tile {
-        padding-left: 16px;
-
-      }
-    }
-
-    .v-list__group__header__prepend-icon {
-      min-width: unset;
-      padding: 0;
-      margin: 0;
-      justify-content: flex-end;
-      z-index: 1;
-      position: absolute;
-      left: 8px;
-      top: 0;
-      height: 100%;
-    }
-  }
-
-  .sub-level {
-    margin: 4px 0 4px 24px;
-
-    .v-list__tile {
-      height: 32px;
-    }
-  }
-
-  > .v-list {
-    .top-level {
-      > .v-list__tile {
-        margin-left: 8px;
-
-        .v-list__tile__title  {
-          padding-left: 8px;
-        }
-      }
-    }
-
-    .sub-level {
-      > .v-list__tile {
-        margin-left: 8px;
-
-        .v-list__tile__title  {
-          padding-left: 4px;
-        }
-      }
-    }
-
-    .top-level,
-    .sub-level {
-      > .v-list__tile {
-        border-radius: 24px 0 0 24px;
-
-        .v-list__tile__title  {
-          font-size: 16px;
-        }
-      }
-
-      > .v-list__tile--active {
-        background-color: #37474f;
-        color: white;
-
-        &:hover {
-          background-color: #4b616d;
-        }
-
-        i,
-        .v-list__tile__title {
-          color: white;
-        }
-      }
-    }
-  }
-}
-</style>

--- a/web/src/components/Pretreatment.vue
+++ b/web/src/components/Pretreatment.vue
@@ -28,12 +28,11 @@ export default {
     isMerged(dataset) {
       return this.$store.getters.isMerged(dataset.id);
     },
-    problemNav(problem) {
-      const { id } = this;
+    problemNav(problem, id) {
       if (problem.multi) {
-        this.$router.push({ name: 'Problem', params: { id, problem: problem.type } });
+        this.$router.push({ name: 'Problem', params: { id, problem: problem.type } }).catch(() => {});
       } else {
-        this.$router.push({ name: 'Clean Up Table', params: { id } });
+        this.$router.push({ name: 'Clean Up Table', params: { id } }).catch(() => {});
         this.$store.commit(SET_SELECTION, {
           key: id,
           event: {},
@@ -59,81 +58,97 @@ v-layout.pretreatment-component(row, fill-height)
           :value="dataset.id === id")
         template(#activator)
           v-list-tile.mr-0.pr-2(
+              @click.stop="",
+              active-class="font-weight-bold",
               :to="{ name: 'Pretreat Data', params: { id: dataset.id } }",
               exact)
-            v-list-tile-title.body-2.grow
+            v-list-tile-title.grow
               | {{ dataset.name }}
-            v-list-tile-action
+            v-list-tile-action.action-style
               v-icon(color="warning", v-if="dataset.validation.length")
                 | {{ $vuetify.icons.warning }}
               v-icon(color="success", v-else)
                 | {{ $vuetify.icons.check }}
 
-        v-list-tile(:to="{ name: 'Clean Up Table', params: { id: dataset.id } }", exact)
-          v-list-tile-action
+        v-list-tile(
+            :to="{ name: 'Clean Up Table', params: { id: dataset.id } }",
+            exact,
+            active-class="font-weight-bold")
+          v-list-tile-action.action-style
             v-icon {{ $vuetify.icons.tableEdit }}
           v-list-tile-content
             v-list-tile-title
               | Clean Up Table
 
-        v-list-tile(v-for="problemData in dataset.validation",
-            @click="problemNav(problemData)",
+        v-list-tile(
+            v-for="problemData in dataset.validation",
+            @click="problemNav(problemData, dataset.id)",
             :class="{ active: problemData.type === problem && dataset.id === id}",
             :inactive="!problemData.clickable",
-            :key="problemData.title")
-          v-list-tile-action
+            :key="problemData.title",
+            active-class="font-weight-bold")
+          v-list-tile-action.action-style
             v-icon.pr-1(
                 :color="problemData.severity") {{ $vuetify.icons[problemData.severity] }}
           v-list-tile-content
-            v-list-tile-title
-              | {{ problemData.title }}
+            v-list-tile-title {{ problemData.title }}
               span(v-if="problemData.data") ({{ problemData.data.length }})
               v-tooltip(v-else, top)
                 template(#activator="{ on }")
                   v-icon.pr-1(small, v-on="on") {{ $vuetify.icons.info }}
                 span {{ problemData.description }}
 
-        v-list-tile(:to="{ name: 'Impute Table', params: { id: dataset.id } }",
-            v-show="!isMerged(dataset)")
-          v-list-tile-action
+        v-list-tile(
+            :to="{ name: 'Impute Table', params: { id: dataset.id } }",
+            v-show="!isMerged(dataset)",
+            active-class="font-weight-bold")
+          v-list-tile-action.action-style
             v-icon.pr-1 {{ $vuetify.icons.tableEdit }}
           v-list-tile-content
             v-list-tile-title
               | Impute Table
 
-        v-list-tile(:to="{ name: 'Transform Table', params: { id: dataset.id } }",
-            :disabled="!valid(dataset)", v-show="!isMerged(dataset)")
-          v-list-tile-action
+        v-list-tile(
+            :to="{ name: 'Transform Table', params: { id: dataset.id } }",
+            :disabled="!valid(dataset)", v-show="!isMerged(dataset)",
+            active-class="font-weight-bold")
+          v-list-tile-action.action-style
             v-icon.pr-1 {{ $vuetify.icons.bubbles }}
           v-list-tile-content
             v-list-tile-title
               | Transform Table
 
-        v-list
+        v-list.py-0
           v-list-group(
               :class="{ active: $route.name === 'Analyze Data' && dataset.id === id}")
             template(#activator)
               v-list-tile(
                   :to="{ name: 'Analyze Data', params: { id: dataset.id } }",
+                  :disabled="!valid(dataset)",
                   exact,
-                  :disabled="!valid(dataset)")
-                v-list-tile-action
+                  active-class="font-weight-bold")
+                v-list-tile-action.action-style
                   v-icon.pr-1 {{ $vuetify.icons.cogs }}
                 v-list-tile-content
                   v-list-tile-title
                     | Analyze Table
-            v-list-tile(v-for="a in analyses", :key="a.path",
+            v-list-tile(
+                v-for="a in analyses",
+                :key="a.path",
                 :to="{ name: a.shortName, params: { id: dataset.id } }",
-                :disabled="!valid(dataset)")
-              v-list-tile-action
+                :disabled="!valid(dataset)",
+                active-class="font-weight-bold")
+              v-list-tile-action.action-style
                 v-icon.pr-1(:style="a.iconStyle") {{ a.icon || $vuetify.icons.compare }}
               v-list-tile-content
                 v-list-tile-title
                   | {{a.shortName}}
 
-        v-list-tile(:to="{ name: 'Download Data', params: { id: dataset.id } }",
-            :disabled="!valid(dataset)")
-          v-list-tile-action
+        v-list-tile(
+            :to="{ name: 'Download Data', params: { id: dataset.id } }",
+            :disabled="!valid(dataset)",
+            active-class="font-weight-bold")
+          v-list-tile-action.action-style
             v-icon.pr-1 {{ $vuetify.icons.fileDownload }}
           v-list-tile-content
             v-list-tile-title
@@ -141,3 +156,9 @@ v-layout.pretreatment-component(row, fill-height)
 
   router-view
 </template>
+
+<style scoped>
+.action-style {
+  min-width: 40px !important;
+}
+</style>

--- a/web/src/main.ts
+++ b/web/src/main.ts
@@ -18,9 +18,19 @@ import { SessionStore } from './utils';
 Vue.use(Vuetify, vuetifyConfig);
 Vue.config.productionTip = false;
 
-const serverURL = (new URL('/api/v1', process.env.VUE_APP_SERVER_ADDRESS)).href;
+let serverUrl;
 
-ApiService.init(serverURL);
+try {
+  serverUrl = (new URL('/api/v1', process.env.VUE_APP_SERVER_ADDRESS)).href;
+} catch {
+  if (process.env.NODE_ENV !== 'production') {
+    serverUrl = '/api/v1';
+  } else {
+    throw new Error('Must set VUE_APP_SERVER_ADDRESS in production');
+  }
+}
+
+ApiService.init(serverUrl);
 store.dispatch(LOAD_SESSION, new SessionStore(window));
 
 if (process.env.CONTEXT === 'production') {


### PR DESCRIPTION
Remove a ton of hacky CSS that will have to be gutted before a vuetify upgrade anyway.

This PR damages UX in favor of maintainability.

Notice how sub-lists aren't nicely indented anymore (like Impute Table).

![Screenshot from 2020-06-09 15-02-01](https://user-images.githubusercontent.com/4214172/84188810-315e4500-aa62-11ea-9f3f-01bcf9564ecb.png)
