### PR TITLE
Fix upload error handling

### DIFF
--- a/web/src/components/Upload.vue
+++ b/web/src/components/Upload.vue
@@ -110,7 +110,9 @@ export default {
             file.status = 'done';
           } catch (err) {
             file.status = 'error';
-            file.meta = err.response.data;
+            if (err.response) {
+              file.meta = err.response.data;
+            }
             throw err;
           }
         });


### PR DESCRIPTION
`Upload.vue` assumes that all errors caught during upload are 400s and
have a response body. This causes additional errors when this is not the
case, which mask the real error.

See https://sentry.io/organizations/kitware-data/issues/1449059082/?project=1814179&query=is%3Aunresolved