### PR TITLE
Replace ORM column model with dataclass

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -25,10 +25,10 @@
         },
         "certifi": {
             "hashes": [
-                "sha256:5ad7e9a056d25ffa5082862e36f119f7f7cec6457fa07ee2f8c339814b80c9b1",
-                "sha256:9cd41137dc19af6a5e03b630eefe7d1f458d964d406342dd3edf625839b944cc"
+                "sha256:5930595817496dd21bb8dc35dad090f1c2cd0adfaf21204bf6732ca5d8ee34d3",
+                "sha256:8fc0819f1f30ba15bdb34cceffb9ef04d99f420f68eb75d901e9560b8749fc41"
             ],
-            "version": "==2020.4.5.2"
+            "version": "==2020.6.20"
         },
         "chardet": {
             "hashes": [
@@ -94,10 +94,10 @@
         },
         "idna": {
             "hashes": [
-                "sha256:7588d1c14ae4c77d74036e8c22ff447b26d0fde8f007354fd48a7814db15b7cb",
-                "sha256:a068a21ceac8a4d63dbfd964670474107f541babbd2250d61922f029858365fa"
+                "sha256:b307872f855b18632ce0c21c5e45be78c0ea7ae4c15c828c20788b26921eb3f6",
+                "sha256:b97d804b1e9b523befed77c48dacec60e6dcb0b5391d57af6a65a312a90648c0"
             ],
-            "version": "==2.9"
+            "version": "==2.10"
         },
         "itsdangerous": {
             "hashes": [
@@ -115,10 +115,10 @@
         },
         "joblib": {
             "hashes": [
-                "sha256:61e49189c84b3c5d99a969d314853f4d1d263316cc694bec17548ebaa9c47b6e",
-                "sha256:6825784ffda353cc8a1be573118085789e5b5d29401856b35b756645ab5aecb5"
+                "sha256:8f52bf24c64b608bf0b2563e0e47d6fcf516abc8cfafe10cfd98ad66d94f92d6",
+                "sha256:d348c5d4ae31496b2aa060d6d9b787864dd204f9480baaa52d18850cb43e9f49"
             ],
-            "version": "==0.15.1"
+            "version": "==0.16.0"
         },
         "kiwisolver": {
             "hashes": [
@@ -184,81 +184,113 @@
         },
         "matplotlib": {
             "hashes": [
-                "sha256:2466d4dddeb0f5666fd1e6736cc5287a4f9f7ae6c1a9e0779deff798b28e1d35",
-                "sha256:282b3fc8023c4365bad924d1bb442ddc565c2d1635f210b700722776da466ca3",
-                "sha256:4bb50ee4755271a2017b070984bcb788d483a8ce3132fab68393d1555b62d4ba",
-                "sha256:56d3147714da5c7ac4bc452d041e70e0e0b07c763f604110bd4e2527f320b86d",
-                "sha256:7a9baefad265907c6f0b037c8c35a10cf437f7708c27415a5513cf09ac6d6ddd",
-                "sha256:aae7d107dc37b4bb72dcc45f70394e6df2e5e92ac4079761aacd0e2ad1d3b1f7",
-                "sha256:af14e77829c5b5d5be11858d042d6f2459878f8e296228c7ea13ec1fd308eb68",
-                "sha256:c1cf735970b7cd424502719b44288b21089863aaaab099f55e0283a721aaf781",
-                "sha256:ce378047902b7a05546b6485b14df77b2ff207a0054e60c10b5680132090c8ee",
-                "sha256:d35891a86a4388b6965c2d527b9a9f9e657d9e110b0575ca8a24ba0d4e34b8fc",
-                "sha256:e06304686209331f99640642dee08781a9d55c6e32abb45ed54f021f46ccae47",
-                "sha256:e20ba7fb37d4647ac38f3c6d8672dd8b62451ee16173a0711b37ba0ce42bf37d",
-                "sha256:f4412241e32d0f8d3713b68d3ca6430190a5e8a7c070f1c07d7833d8c5264398",
-                "sha256:ffe2f9cdcea1086fc414e82f42271ecf1976700b8edd16ca9d376189c6d93aee"
+                "sha256:1a05eeb5a5f9f35a0d69a01c9efc9ca48e6d6fdc907da8fbad28b33bc839905b",
+                "sha256:2382d2a2df7ec99f92843161ce4c7bb54189a4aeb139c16baf92fa3f5c930ade",
+                "sha256:28c3b07079343d7be300cf4e33f95a700a2bb0fefa7cce05e8016a0c15e3f7bc",
+                "sha256:2ae5f279e6d9afc25cde907c514b2819bbd8a59551c883aa96777077635127ef",
+                "sha256:44d5f9c556a06566e572c31e977fe750cc5fc25ad1983b99dbb0c9cb373ecc78",
+                "sha256:6ca6bf7e10c9387d3ce4b6c2faae28cba404d0824c3dc40072f00919dff9015e",
+                "sha256:7010a0cc96303b7f7b436367fe58f37ca92a89e864202c43c3a284bdde26baf1",
+                "sha256:9da4ad25ed5e1786b24ee19aa2caedcde6a31844521d6b546dafd418b87c3c6c",
+                "sha256:9fef911a7cd3f36707c3cd812030e09a7d4f557b4d3d964e6a4ca782dddb11de",
+                "sha256:a53494c7e29139d96eccbbc91dd281382b6219645d91422046b494b3f24a2774",
+                "sha256:b2425f5ab2914ccc7dde37d7811a7fdf5284bf9e6dfa72ac649da1f1a13db550",
+                "sha256:bcc4803720e58ace1e51009015899248b7d64eecb02e4838516a47a9934a190f",
+                "sha256:d3e7a68de6e74f1f2936ea64d327733876d50aa6b1c0e0c7d51de19391204426",
+                "sha256:e5c4a30195bf262284ec3a4e28f0f8c31898f66d7124e143f851ffa981af291b",
+                "sha256:e7c54447ffd658099f2fb14e0e70a19eced523ce8caae38e65cec2fa807c3050"
             ],
-            "version": "==3.2.1"
+            "version": "==3.3.0rc1"
         },
         "numpy": {
             "hashes": [
-                "sha256:01e17a9c1fdc7b97c75ad926f816694397be76251222a6f6cb50bbe3218cf3e5",
-                "sha256:159741a29c33b5e2829e4fcdcd712c35651f1b7571672002453f27fe438459d4",
-                "sha256:307da8faeb1e84bbee082004c06aa41510e52321025d4a54a16ca48f8329ca4f",
-                "sha256:32073a47eeb37172f23f4f432efb2068c6b13b04d3eb4f0558056430ee3f32c5",
-                "sha256:3eb013e193de97ec196441f6bdf9a1bea84dfbfb2421d5cccfdbba3aa2d60ec0",
-                "sha256:45c0a742198566b46479231cb4f189f69c4fd8fe1331f1217f9c58496fe52fc2",
-                "sha256:53564bfd09dda34cd74d11cbc1aad88b7fd2ad8b1d6eae6b4274ac789f30d6c0",
-                "sha256:5e5b36b986a28d6651f6c8ebed084290e30833f50a7e0fe04f916b59d5113863",
-                "sha256:6068db7fc6e34aed8a2d4ea4041fbeff3485a05452524d307c70da708ea40d63",
-                "sha256:612878ef8025af60c9d43556e45d93fa07d2e6a960e252a475575d3018e361cc",
-                "sha256:707be2715ca33f98335fdc84e3a79de4d85c7dd6b24aff6a57e45bf393205eb5",
-                "sha256:7526a8dbc68d730785a57ec18541b194d4ac7402843addb0d706174668f5be16",
-                "sha256:7c716527392f34c217f18672aac79e88f4747e2717bd0c0c99755b197a5f5197",
-                "sha256:93bb0c1f9c69e5ce97e8d6b45c472a050bfa1e433c4c70c4568718c60cc7c306",
-                "sha256:9e8bf8bb69ef268eaab6483b354039aabb737c3aaab4ad526e4ad7c95a87bd3c",
-                "sha256:a233044f7100e9f2100a4fc0f82021c827f7a82624b649059c5dd92cec4cee17",
-                "sha256:b82511ae4d8e3dbf727c91bf6c761f882750428e888e0c1795b57f3c4b8cfc1e",
-                "sha256:c2f32979427df01cda8834af714dfacd06dce92f6c9275482a2e2932c67e67a1",
-                "sha256:c49cc2b4e1b40bd836b2077d1cfee738577d2a411268eccace4f01dc22ef90ed",
-                "sha256:cf6a8eb39bd191584de2f47dcc40155ffc902a32cff2a985ac58d93c035b306a",
-                "sha256:d9b07673ac07cd02b1ba4d7eb920cd762d1559cc40af63d8e2b16774fdc3aa36",
-                "sha256:dd21db931bdeb5d6ecffe36673bbaee4510f7e79b9afdbbdc2bf9c157ec8734c",
-                "sha256:e1c4e32318501ec8e8fa3dead802dd1b913dcf8eddeb2b0370f35b58c71d6018",
-                "sha256:e20452ad415c56cec51f52080adb4eccc4891ee86cf6b194e2434d09d42a183d",
-                "sha256:e9ad332f8ff6f53dba38f39f3832a2f9fd4627039bc3a2baddb699fdf445adb1",
-                "sha256:ec6c41348e05e2bee6b34cedb5bb38f7e53dee7e0791a4a63e1425dbee5ef326"
+                "sha256:13af0184177469192d80db9bd02619f6fa8b922f9f327e077d6f2a6acb1ce1c0",
+                "sha256:26a45798ca2a4e168d00de75d4a524abf5907949231512f372b217ede3429e98",
+                "sha256:26f509450db547e4dfa3ec739419b31edad646d21fb8d0ed0734188b35ff6b27",
+                "sha256:30a59fb41bb6b8c465ab50d60a1b298d1cd7b85274e71f38af5a75d6c475d2d2",
+                "sha256:33c623ef9ca5e19e05991f127c1be5aeb1ab5cdf30cb1c5cf3960752e58b599b",
+                "sha256:356f96c9fbec59974a592452ab6a036cd6f180822a60b529a975c9467fcd5f23",
+                "sha256:3c40c827d36c6d1c3cf413694d7dc843d50997ebffbc7c87d888a203ed6403a7",
+                "sha256:4d054f013a1983551254e2379385e359884e5af105e3efe00418977d02f634a7",
+                "sha256:63d971bb211ad3ca37b2adecdd5365f40f3b741a455beecba70fd0dde8b2a4cb",
+                "sha256:658624a11f6e1c252b2cd170d94bf28c8f9410acab9f2fd4369e11e1cd4e1aaf",
+                "sha256:76766cc80d6128750075378d3bb7812cf146415bd29b588616f72c943c00d598",
+                "sha256:7b57f26e5e6ee2f14f960db46bd58ffdca25ca06dd997729b1b179fddd35f5a3",
+                "sha256:7b852817800eb02e109ae4a9cef2beda8dd50d98b76b6cfb7b5c0099d27b52d4",
+                "sha256:8cde829f14bd38f6da7b2954be0f2837043e8b8d7a9110ec5e318ae6bf706610",
+                "sha256:a2e3a39f43f0ce95204beb8fe0831199542ccab1e0c6e486a0b4947256215632",
+                "sha256:a86c962e211f37edd61d6e11bb4df7eddc4a519a38a856e20a6498c319efa6b0",
+                "sha256:a8705c5073fe3fcc297fb8e0b31aa794e05af6a329e81b7ca4ffecab7f2b95ef",
+                "sha256:b6aaeadf1e4866ca0fdf7bb4eed25e521ae21a7947c59f78154b24fc7abbe1dd",
+                "sha256:be62aeff8f2f054eff7725f502f6228298891fd648dc2630e03e44bf63e8cee0",
+                "sha256:c2edbb783c841e36ca0fa159f0ae97a88ce8137fb3a6cd82eae77349ba4b607b",
+                "sha256:cbe326f6d364375a8e5a8ccb7e9cd73f4b2f6dc3b2ed205633a0db8243e2a96a",
+                "sha256:d34fbb98ad0d6b563b95de852a284074514331e6b9da0a9fc894fb1cdae7a79e",
+                "sha256:d97a86937cf9970453c3b62abb55a6475f173347b4cde7f8dcdb48c8e1b9952d",
+                "sha256:dd53d7c4a69e766e4900f29db5872f5824a06827d594427cf1a4aa542818b796",
+                "sha256:df1889701e2dfd8ba4dc9b1a010f0a60950077fb5242bb92c8b5c7f1a6f2668a",
+                "sha256:fa1fe75b4a9e18b66ae7f0b122543c42debcf800aaafa0212aaff3ad273c2596"
             ],
-            "version": "==1.19.0rc2"
+            "version": "==1.19.0"
         },
         "pandas": {
             "hashes": [
-                "sha256:034185bb615dc96d08fa13aacba8862949db19d5e7804d6ee242d086f07bcc46",
-                "sha256:0c9b7f1933e3226cc16129cf2093338d63ace5c85db7c9588e3e1ac5c1937ad5",
-                "sha256:1f6fcf0404626ca0475715da045a878c7062ed39bc859afc4ccf0ba0a586a0aa",
-                "sha256:1fc963ba33c299973e92d45466e576d11f28611f3549469aec4a35658ef9f4cc",
-                "sha256:29b4cfee5df2bc885607b8f016e901e63df7ffc8f00209000471778f46cc6678",
-                "sha256:2a8b6c28607e3f3c344fe3e9b3cd76d2bf9f59bc8c0f2e582e3728b80e1786dc",
-                "sha256:2bc2ff52091a6ac481cc75d514f06227dc1b10887df1eb72d535475e7b825e31",
-                "sha256:415e4d52fcfd68c3d8f1851cef4d947399232741cc994c8f6aa5e6a9f2e4b1d8",
-                "sha256:519678882fd0587410ece91e3ff7f73ad6ded60f6fcb8aa7bcc85c1dc20ecac6",
-                "sha256:51e0abe6e9f5096d246232b461649b0aa627f46de8f6344597ca908f2240cbaa",
-                "sha256:698e26372dba93f3aeb09cd7da2bb6dd6ade248338cfe423792c07116297f8f4",
-                "sha256:83af85c8e539a7876d23b78433d90f6a0e8aa913e37320785cf3888c946ee874",
-                "sha256:982cda36d1773076a415ec62766b3c0a21cdbae84525135bdb8f460c489bb5dd",
-                "sha256:a647e44ba1b3344ebc5991c8aafeb7cca2b930010923657a273b41d86ae225c4",
-                "sha256:b35d625282baa7b51e82e52622c300a1ca9f786711b2af7cbe64f1e6831f4126",
-                "sha256:bab51855f8b318ef39c2af2c11095f45a10b74cbab4e3c8199efcc5af314c648"
+                "sha256:02f1e8f71cd994ed7fcb9a35b6ddddeb4314822a0e09a9c5b2d278f8cb5d4096",
+                "sha256:13f75fb18486759da3ff40f5345d9dd20e7d78f2a39c5884d013456cec9876f0",
+                "sha256:35b670b0abcfed7cad76f2834041dcf7ae47fd9b22b63622d67cdc933d79f453",
+                "sha256:4c73f373b0800eb3062ffd13d4a7a2a6d522792fa6eb204d67a4fad0a40f03dc",
+                "sha256:5759edf0b686b6f25a5d4a447ea588983a33afc8a0081a0954184a4a87fd0dd7",
+                "sha256:5a7cf6044467c1356b2b49ef69e50bf4d231e773c3ca0558807cdba56b76820b",
+                "sha256:69c5d920a0b2a9838e677f78f4dde506b95ea8e4d30da25859db6469ded84fa8",
+                "sha256:8778a5cc5a8437a561e3276b85367412e10ae9fff07db1eed986e427d9a674f8",
+                "sha256:9871ef5ee17f388f1cb35f76dc6106d40cb8165c562d573470672f4cdefa59ef",
+                "sha256:9c31d52f1a7dd2bb4681d9f62646c7aa554f19e8e9addc17e8b1b20011d7522d",
+                "sha256:ab8173a8efe5418bbe50e43f321994ac6673afc5c7c4839014cf6401bbdd0705",
+                "sha256:ae961f1f0e270f1e4e2273f6a539b2ea33248e0e3a11ffb479d757918a5e03a9",
+                "sha256:b3c4f93fcb6e97d993bf87cdd917883b7dab7d20c627699f360a8fb49e9e0b91",
+                "sha256:c9410ce8a3dee77653bc0684cfa1535a7f9c291663bd7ad79e39f5ab58f67ab3",
+                "sha256:f69e0f7b7c09f1f612b1f8f59e2df72faa8a6b41c5a436dde5b615aaf948f107",
+                "sha256:faa42a78d1350b02a7d2f0dbe3c80791cf785663d6997891549d0f86dc49125e"
             ],
-            "version": "==1.0.4"
+            "version": "==1.0.5"
+        },
+        "pillow": {
+            "hashes": [
+                "sha256:0295442429645fa16d05bd567ef5cff178482439c9aad0411d3f0ce9b88b3a6f",
+                "sha256:06aba4169e78c439d528fdeb34762c3b61a70813527a2c57f0540541e9f433a8",
+                "sha256:09d7f9e64289cb40c2c8d7ad674b2ed6105f55dc3b09aa8e4918e20a0311e7ad",
+                "sha256:0a80dd307a5d8440b0a08bd7b81617e04d870e40a3e46a32d9c246e54705e86f",
+                "sha256:1ca594126d3c4def54babee699c055a913efb01e106c309fa6b04405d474d5ae",
+                "sha256:25930fadde8019f374400f7986e8404c8b781ce519da27792cbe46eabec00c4d",
+                "sha256:431b15cffbf949e89df2f7b48528be18b78bfa5177cb3036284a5508159492b5",
+                "sha256:52125833b070791fcb5710fabc640fc1df07d087fc0c0f02d3661f76c23c5b8b",
+                "sha256:5e51ee2b8114def244384eda1c82b10e307ad9778dac5c83fb0943775a653cd8",
+                "sha256:612cfda94e9c8346f239bf1a4b082fdd5c8143cf82d685ba2dba76e7adeeb233",
+                "sha256:6d7741e65835716ceea0fd13a7d0192961212fd59e741a46bbed7a473c634ed6",
+                "sha256:6edb5446f44d901e8683ffb25ebdfc26988ee813da3bf91e12252b57ac163727",
+                "sha256:725aa6cfc66ce2857d585f06e9519a1cc0ef6d13f186ff3447ab6dff0a09bc7f",
+                "sha256:8dad18b69f710bf3a001d2bf3afab7c432785d94fcf819c16b5207b1cfd17d38",
+                "sha256:94cf49723928eb6070a892cb39d6c156f7b5a2db4e8971cb958f7b6b104fb4c4",
+                "sha256:97f9e7953a77d5a70f49b9a48da7776dc51e9b738151b22dacf101641594a626",
+                "sha256:9ad7f865eebde135d526bb3163d0b23ffff365cf87e767c649550964ad72785d",
+                "sha256:a060cf8aa332052df2158e5a119303965be92c3da6f2d93b6878f0ebca80b2f6",
+                "sha256:c79f9c5fb846285f943aafeafda3358992d64f0ef58566e23484132ecd8d7d63",
+                "sha256:c92302a33138409e8f1ad16731568c55c9053eee71bb05b6b744067e1b62380f",
+                "sha256:d08b23fdb388c0715990cbc06866db554e1822c4bdcf6d4166cf30ac82df8c41",
+                "sha256:d350f0f2c2421e65fbc62690f26b59b0bcda1b614beb318c81e38647e0f673a1",
+                "sha256:ec29604081f10f16a7aea809ad42e27764188fc258b02259a03a8ff7ded3808d",
+                "sha256:edf31f1150778abd4322444c393ab9c7bd2af271dd4dafb4208fb613b1f3cdc9",
+                "sha256:f7e30c27477dffc3e85c2463b3e649f751789e0f6c8456099eea7ddd53be4a8a",
+                "sha256:ffe538682dc19cc542ae7c3e504fdf54ca7f86fb8a135e59dd6bc8627eae6cce"
+            ],
+            "version": "==7.2.0"
         },
         "pyparsing": {
             "hashes": [
-                "sha256:67199f0c41a9c702154efb0e7a8cc08accf830eb003b4d9fa42c4059002e2492",
-                "sha256:700d17888d441604b0bd51535908dcb297561b040819cccde647a92439db5a2a"
+                "sha256:1060635ca5ac864c2b7bc7b05a448df4e32d7d8c65e33cbe1514810d339672a2",
+                "sha256:56a551039101858c9e189ac9e66e330a03fb7079e97ba6b50193643905f450ce"
             ],
-            "version": "==3.0.0a1"
+            "version": "==3.0.0a2"
         },
         "python-dateutil": {
             "hashes": [
@@ -291,10 +323,10 @@
         },
         "requests": {
             "hashes": [
-                "sha256:43999036bfa82904b6af1d99e4882b560e5e2c68e5c4b0aa03b655f3d7d73fee",
-                "sha256:b3f43d496c6daba4493e7c431722aeb7dbc6288f52a6e04e7b6023b0247817e6"
+                "sha256:b3559a131db72c33ee969480840fff4bb6dd111de7dd27c8ee1f820f4f00231b",
+                "sha256:fe75cc94a9443b9246fc7049224f75604b113c36acb93f87b80ed42c44cbb898"
             ],
-            "version": "==2.23.0"
+            "version": "==2.24.0"
         },
         "scikit-learn": {
             "hashes": [
@@ -319,24 +351,24 @@
         },
         "scipy": {
             "hashes": [
-                "sha256:142649a4487e8849aa7e3ea11e010f6201683ed56adc02270d2c7a8cdb93a7e8",
-                "sha256:1f402f14e726d41fd34e30b6c54daac36ac84ee64c4a430ed4b5ec016705e053",
-                "sha256:1f57d75c49f6c8b17b4d9217011e5ecca4d04941eb79a465bdfdf9591f09a312",
-                "sha256:25db07c206d81c9dd9b9a0ea4ea4a134026e4cddc83968e99bc2b95ce2b3c760",
-                "sha256:2a0d8504a08507d6e7b5c2b65db11fdb10ca63245166a5496fe3a781d0d9a452",
-                "sha256:38cf18ab60d853113137229e328c97719c22b02d3bf8873349472103015de5f7",
-                "sha256:52998372c9179ebfbf7e875e4cb29137d4edc2b9d6614c5e57a180501dacf4f0",
-                "sha256:52b693c1f842e126efb7882038680fed920fc2014cad3a16da4673e41dc8d0a9",
-                "sha256:6591dc05981308fb620c3705bf684b57241b73fe9369748f36eaf7069969c67e",
-                "sha256:a705d1c6b8b9b7a3f5f57aec792be3fce2d65cdf49a8559852084aa18c57af1e",
-                "sha256:b5d756e25e26184d19172db49b185a05c618d7c1323588fa261563b451b0dc7b",
-                "sha256:ce0164965caadd3a53583ad63643679ccea70b6bb25a691e4a74d3e87e3fffea",
-                "sha256:d395b63f6bfb737f3b45c8253af7e1761af1cc015db7347cbaacf1f643f3f7b8",
-                "sha256:e90d679b96b9cbd249e900b2d03558bb01ae161aa9400e9b6cd435cce82552ea",
-                "sha256:eabc685cae91a899f6eff8aed3db3df2ad884df3b46f85314b5ca016d5bb93ea",
-                "sha256:fb642c6c4a19feeeee84a74d1e38c16952fde36c752e4c4a8ed70f9e4d70d5c7"
+                "sha256:0f62f3be924a4314cf2384c6f77d3a0e3bf4ada370530a7d0a6d5a61192bec9e",
+                "sha256:11d8bfcea08e971968d07495bdf1de37b3b1bb5ca78e4ddbe8d60791f0456942",
+                "sha256:1b23129e9838694c36475b296ac251ae0b0247455352f2bed0b246c30b61c822",
+                "sha256:244b4a23a8cb6707e19f5579502112954659bb983852b1c381243fe46d9b6818",
+                "sha256:2aec0f81a29440e0c000222ac0447748a840d328b5698dd900ece4113bca5cde",
+                "sha256:2e99f50d0061c385f8f46c5a99bb07ad013ec2dcf95ccba3be4e081594e7ab19",
+                "sha256:38cdb4eafe727b324f295ab69eaa0788a8eefe08d59360968928753ab7f68ba9",
+                "sha256:40969696eb13c2f1b6fc8e99ce597a47627f0167a7feb6086c2ccdfb55835cfc",
+                "sha256:4e1a790fdf82a67619a38f017105df4bb66dfcdaea45df793ece27fd534720c2",
+                "sha256:4ff72877d19b295ee7f7727615ea8238f2d59159df0bdd98f91754be4a2767f0",
+                "sha256:69eb6245ff472db406c3e9b3e13bd0dc6e2ff48e7e758a7bfca296ecdb1ae8b9",
+                "sha256:8f354e92246de33c44ddfc5fef61bce8c19d5aeeb2130b6a672b15db619453e4",
+                "sha256:ae24f16056c87e7f086a56a7aaf6e65e4626ac70b7e08d7f54e078693abcf778",
+                "sha256:d266d955c3fd12336c948abb368de230bf8dc20efad428abb908165d9c87f53f",
+                "sha256:eb48915142f2dbd4b84df8ca66e433946df1a13eff36015c2b7843aa39dbc30d",
+                "sha256:f662ad49ef930325161bd5edac39932c3f1b55547eaa0afce08367522f6314df"
             ],
-            "version": "==1.5.0rc1"
+            "version": "==1.5.0"
         },
         "six": {
             "hashes": [
@@ -353,42 +385,42 @@
         },
         "sqlalchemy": {
             "hashes": [
-                "sha256:128bc917ed20d78143a45024455ff0aed7d3b96772eba13d5dbaf9cc57e5c41b",
-                "sha256:156a27548ba4e1fed944ff9fcdc150633e61d350d673ae7baaf6c25c04ac1f71",
-                "sha256:27e2efc8f77661c9af2681755974205e7462f1ae126f498f4fe12a8b24761d15",
-                "sha256:2a12f8be25b9ea3d1d5b165202181f2b7da4b3395289000284e5bb86154ce87c",
-                "sha256:31c043d5211aa0e0773821fcc318eb5cbe2ec916dfbc4c6eea0c5188971988eb",
-                "sha256:65eb3b03229f684af0cf0ad3bcc771970c1260a82a791a8d07bffb63d8c95bcc",
-                "sha256:6cd157ce74a911325e164441ff2d9b4e244659a25b3146310518d83202f15f7a",
-                "sha256:703c002277f0fbc3c04d0ae4989a174753a7554b2963c584ce2ec0cddcf2bc53",
-                "sha256:869bbb637de58ab0a912b7f20e9192132f9fbc47fc6b5111cd1e0f6cdf5cf9b0",
-                "sha256:8a0e0cd21da047ea10267c37caf12add400a92f0620c8bc09e4a6531a765d6d7",
-                "sha256:8d01e949a5d22e5c4800d59b50617c56125fc187fbeb8fa423e99858546de616",
-                "sha256:925b4fe5e7c03ed76912b75a9a41dfd682d59c0be43bce88d3b27f7f5ba028fb",
-                "sha256:9cb1819008f0225a7c066cac8bb0cf90847b2c4a6eb9ebb7431dbd00c56c06c5",
-                "sha256:a87d496884f40c94c85a647c385f4fd5887941d2609f71043e2b73f2436d9c65",
-                "sha256:a9030cd30caf848a13a192c5e45367e3c6f363726569a56e75dc1151ee26d859",
-                "sha256:a9e75e49a0f1583eee0ce93270232b8e7bb4b1edc89cc70b07600d525aef4f43",
-                "sha256:b50f45d0e82b4562f59f0e0ca511f65e412f2a97d790eea5f60e34e5f1aabc9a",
-                "sha256:b7878e59ec31f12d54b3797689402ee3b5cfcb5598f2ebf26491732758751908",
-                "sha256:ce1ddaadee913543ff0154021d31b134551f63428065168e756d90bdc4c686f5",
-                "sha256:ce2646e4c0807f3461be0653502bb48c6e91a5171d6e450367082c79e12868bf",
-                "sha256:ce6c3d18b2a8ce364013d47b9cad71db815df31d55918403f8db7d890c9d07ae",
-                "sha256:e4e2664232005bd306f878b0f167a31f944a07c4de0152c444f8c61bbe3cfb38",
-                "sha256:e8aa395482728de8bdcca9cc0faf3765ab483e81e01923aaa736b42f0294f570",
-                "sha256:eb4fcf7105bf071c71068c6eee47499ab8d4b8f5a11fc35147c934f0faa60f23",
-                "sha256:ed375a79f06cad285166e5be74745df1ed6845c5624aafadec4b7a29c25866ef",
-                "sha256:f35248f7e0d63b234a109dd72fbfb4b5cb6cb6840b221d0df0ecbf54ab087654",
-                "sha256:f502ef245c492b391e0e23e94cba030ab91722dcc56963c85bfd7f3441ea2bbe",
-                "sha256:fe01bac7226499aedf472c62fa3b85b2c619365f3f14dd222ffe4f3aa91e5f98"
+                "sha256:0942a3a0df3f6131580eddd26d99071b48cfe5aaf3eab2783076fbc5a1c1882e",
+                "sha256:0ec575db1b54909750332c2e335c2bb11257883914a03bc5a3306a4488ecc772",
+                "sha256:109581ccc8915001e8037b73c29590e78ce74be49ca0a3630a23831f9e3ed6c7",
+                "sha256:16593fd748944726540cd20f7e83afec816c2ac96b082e26ae226e8f7e9688cf",
+                "sha256:427273b08efc16a85aa2b39892817e78e3ed074fcb89b2a51c4979bae7e7ba98",
+                "sha256:50c4ee32f0e1581828843267d8de35c3298e86ceecd5e9017dc45788be70a864",
+                "sha256:512a85c3c8c3995cc91af3e90f38f460da5d3cade8dc3a229c8e0879037547c9",
+                "sha256:57aa843b783179ab72e863512e14bdcba186641daf69e4e3a5761d705dcc35b1",
+                "sha256:621f58cd921cd71ba6215c42954ffaa8a918eecd8c535d97befa1a8acad986dd",
+                "sha256:6ac2558631a81b85e7fb7a44e5035347938b0a73f5fdc27a8566777d0792a6a4",
+                "sha256:716754d0b5490bdcf68e1e4925edc02ac07209883314ad01a137642ddb2056f1",
+                "sha256:736d41cfebedecc6f159fc4ac0769dc89528a989471dc1d378ba07d29a60ba1c",
+                "sha256:8619b86cb68b185a778635be5b3e6018623c0761dde4df2f112896424aa27bd8",
+                "sha256:87fad64529cde4f1914a5b9c383628e1a8f9e3930304c09cf22c2ae118a1280e",
+                "sha256:89494df7f93b1836cae210c42864b292f9b31eeabca4810193761990dc689cce",
+                "sha256:8cac7bb373a5f1423e28de3fd5fc8063b9c8ffe8957dc1b1a59cb90453db6da1",
+                "sha256:8fd452dc3d49b3cc54483e033de6c006c304432e6f84b74d7b2c68afa2569ae5",
+                "sha256:adad60eea2c4c2a1875eb6305a0b6e61a83163f8e233586a4d6a55221ef984fe",
+                "sha256:c26f95e7609b821b5f08a72dab929baa0d685406b953efd7c89423a511d5c413",
+                "sha256:cbe1324ef52ff26ccde2cb84b8593c8bf930069dfc06c1e616f1bfd4e47f48a3",
+                "sha256:d05c4adae06bd0c7f696ae3ec8d993ed8ffcc4e11a76b1b35a5af8a099bd2284",
+                "sha256:d98bc827a1293ae767c8f2f18be3bb5151fd37ddcd7da2a5f9581baeeb7a3fa1",
+                "sha256:da2fb75f64792c1fc64c82313a00c728a7c301efe6a60b7a9fe35b16b4368ce7",
+                "sha256:e4624d7edb2576cd72bb83636cd71c8ce544d8e272f308bd80885056972ca299",
+                "sha256:e89e0d9e106f8a9180a4ca92a6adde60c58b1b0299e1b43bd5e0312f535fbf33",
+                "sha256:f11c2437fb5f812d020932119ba02d9e2bc29a6eca01a055233a8b449e3e1e7d",
+                "sha256:f57be5673e12763dd400fea568608700a63ce1c6bd5bdbc3cc3a2c5fdb045274",
+                "sha256:fc728ece3d5c772c196fd338a99798e7efac7a04f9cb6416299a3638ee9a94cd"
             ],
-            "version": "==1.3.17"
+            "version": "==1.3.18"
         },
         "sqlalchemy-utils": {
             "hashes": [
-                "sha256:7a7fab14bed80df065412bbf71a0a9b0bfeb4b7c111c2d9bffe57283082f3a6b"
+                "sha256:be319a16022b6a01e1d6c838340485beb4d34fd9c1c19d2303356804fa0faa09"
             ],
-            "version": "==0.36.6"
+            "version": "==0.36.7"
         },
         "threadpoolctl": {
             "hashes": [

--- a/viime/cache.py
+++ b/viime/cache.py
@@ -10,16 +10,12 @@ from pandas.util import hash_pandas_object
 
 
 def hash_argument(arg):
-    from viime.models import CSVFile, TableColumn, TableRow
+    from viime.models import CSVFile
     if isinstance(arg, PandasObject):
         r = hash_pandas_object(arg, index=True)
         return sha256(r.values.tostring()).hexdigest()
     elif isinstance(arg, CSVFile):
         return str(arg.id)
-    elif isinstance(arg, TableColumn):
-        return str(arg.csv_file_id) + str(arg.column_index)
-    elif isinstance(arg, TableRow):
-        return str(arg.csv_file_id) + str(arg.row_index)
 
     return str(arg)
 

--- a/viime/imputation.py
+++ b/viime/imputation.py
@@ -2,14 +2,12 @@ from typing import Dict, List, Tuple
 
 import pandas as pd
 
-from viime.cache import region
 from viime.opencpu import opencpu_request
 
 IMPUTE_MNAR_METHODS = ['zero', 'half-minimum']
 IMPUTE_MCAR_METHODS = ['random-forest', 'knn', 'mean', 'median']
 
 
-@region.cache_on_arguments()
 def impute_missing(table: pd.DataFrame, groups: pd.DataFrame,
                    mnar='zero', mcar='random-forest', p_mnar=0.7,
                    p_mcar=0.4) -> Tuple[pd.DataFrame, Dict[str, List[str]]]:

--- a/viime/models.py
+++ b/viime/models.py
@@ -1,5 +1,4 @@
 from collections import namedtuple
-from dataclasses import dataclass
 from datetime import datetime
 from io import BytesIO
 from pathlib import Path
@@ -16,14 +15,12 @@ from marshmallow.exceptions import ValidationError
 import numpy
 import pandas
 from sqlalchemy import MetaData
-from sqlalchemy.event import listen
-from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.orm import relationship
+from sqlalchemy.orm.attributes import flag_modified
 from sqlalchemy_utils.types.json import JSONType
 from sqlalchemy_utils.types.uuid import UUIDType
 from werkzeug.utils import secure_filename
 
-from viime.cache import clear_cache, region
 from viime.colors import category10
 from viime.imputation import IMPUTE_MCAR_METHODS, impute_missing, IMPUTE_MNAR_METHODS
 from viime.normalization import NORMALIZATION_METHODS, normalize
@@ -122,17 +119,20 @@ class CSVFile(BaseModel):
     row_json = db.Column(JSONType, nullable=False, default=list)
 
     @property
-    def columns(self) -> List['TableColumn']:
-        # TODO: serialization will involve needlessly converting to the dataclass representing and
-        #       back, we can optimize this later.
-        return [TableColumn(**c) for c in self.column_json]
+    def columns(self):
+        if self.column_json is not None:
+            flag_modified(self, 'column_json')
+            return self.column_json
+        else:
+            return []
 
-    @columns.setter
-    def columns(self, columns: List['TableColumn']):
-        # TODO: this will be very inefficient for setting properties on single columns, but
-        #       we can optimize later.
-        table_column_schema = TableColumnSchema()
-        self.column_json = table_column_schema.dump(columns, many=True)
+    @property
+    def rows(self):
+        if self.row_json is not None:
+            flag_modified(self, 'row_json')
+            return self.row_json
+        else:
+            return []
 
     @property
     def table_validation(self):
@@ -145,11 +145,36 @@ class CSVFile(BaseModel):
 
     @property
     def table(self):
-        return _read_csv_file(self.uri, index_col=None, header=None)
+        return pandas.read_csv(self.uri, index_col=None, header=None)
 
     @property
     def indexed_table(self):
-        return _indexed_table(self)
+        kwargs: Dict[str, Any] = {}
+
+        # handle column names
+        header_row = self.header_row_index
+        kwargs['header'] = header_row
+        if header_row is None:
+            kwargs['names'] = self.headers
+
+        # handle row ids
+        kwargs['index_col'] = False
+        key_column = self.key_column_index
+        if key_column is not None:
+            kwargs['index_col'] = key_column
+
+        indexed_table = pandas.read_csv(self.uri, **kwargs)
+
+        # inject the computed keys in case the csv file does not have a primary key column
+        if key_column is None:
+            keys = self.keys
+
+            # exclude the header row from the primary key index if present
+            if header_row is not None:
+                keys = keys[1:]
+            indexed_table.index = pandas.Index(keys)
+
+        return indexed_table
 
     @property
     def measurement_table(self):
@@ -160,7 +185,13 @@ class CSVFile(BaseModel):
     def measurement_table_and_info(self):
         """Return the processed metabolite date table."""
         try:
-            return _get_measurement_table_and_info(self)
+            if not get_fatal_index_errors(self):
+                try:
+                    return self.apply_transforms()
+                except Exception as e:
+                    # TODO: We should handle this better
+                    current_app.logger.exception(e)
+            return None, dict(mcar=[], mnar=[])
         except Exception:
             current_app.logger.exception('Error getting measurement_table')
             raise
@@ -168,22 +199,28 @@ class CSVFile(BaseModel):
     @property
     def measurement_metadata(self):
         """Return metadata rows."""
-        return _get_measurement_metadata(self)
+        return self.filter_table_by_types(TABLE_ROW_TYPES.METADATA, TABLE_COLUMN_TYPES.DATA)
 
     @property
     def sample_metadata(self):
         """Return metadata columns."""
-        return _get_sample_metadata(self)
+        return self.filter_table_by_types(TABLE_ROW_TYPES.DATA, TABLE_COLUMN_TYPES.METADATA)
 
     @property
     def raw_measurement_table(self):
         """Return the metabolite data table before transformation."""
-        return _get_raw_measurement_table(self)
+        return self.filter_table_by_types(TABLE_ROW_TYPES.DATA, TABLE_COLUMN_TYPES.DATA)
 
     @property
     def groups(self):
         """Return a table containing the primary grouping column."""
-        return _get_groups(self)
+        if self.group_column_index is None:
+            return None
+        groups = self.filter_table_by_types(TABLE_ROW_TYPES.DATA, TABLE_COLUMN_TYPES.GROUP)
+        if groups is None:
+            return None
+        # ensure groups are strings
+        return groups.fillna('').astype(str)
 
     @property
     def uri(self) -> Path:
@@ -194,96 +231,86 @@ class CSVFile(BaseModel):
     def size(self) -> int:
         return Path(self.uri).stat().st_size
 
-    # update this property like key_column_index
-    @hybrid_property
+    @property
     def header_row_index(self):
-        return _header_row_index(self)
-
-    @header_row_index.expression  # type: ignore
-    def header_row_index(cls):  # noqa: N805
-        return TableRow.query\
-            .filter_by(csv_file_id=cls.id, row_type=TABLE_ROW_TYPES.INDEX)\
-            .with_entities(TableRow.row_index)\
-            .scalar()
+        row = self.find_first_entity(
+            lambda r: r['row_type'] == TABLE_ROW_TYPES.INDEX, self.rows)
+        return row and row['row_index']
 
     @header_row_index.setter  # type: ignore
     def header_row_index(self, value: Optional[int]):
         if self.header_row_index is not None:
             old_row = self.rows[self.header_row_index]
-            old_row.row_type = TABLE_ROW_TYPES.METADATA
-            db.session.add(old_row)
-            clear_cache()
+            old_row['row_type'] = TABLE_ROW_TYPES.METADATA
+
+            db.session.add(self)
 
         if value is not None:
             new_row = self.rows[value]
-            new_row.row_type = TABLE_ROW_TYPES.INDEX
-            db.session.add(new_row)
-            clear_cache()
+            new_row['row_type'] = TABLE_ROW_TYPES.INDEX
+
+            db.session.add(self)
 
     @property
     def headers(self):
-        return [c.column_header for c in self.columns]
+        return self._headers()
+
+    def _headers(self, header_row_index=None):
+        idx = self.header_row_index or header_row_index
+        if idx is None:
+            return [
+                f'col{i + 1}' for i in range(self.table.shape[1])
+            ]
+
+        return list(self.table.iloc[idx, :])
 
     @property
     def key_column_index(self):
         column = self.find_first_entity(
-            lambda c: c.column_type == TABLE_COLUMN_TYPES.INDEX, self.columns)
-        return column and column.column_index
+            lambda c: c['column_type'] == TABLE_COLUMN_TYPES.INDEX, self.columns)
+        return column and column['column_index']
 
     @key_column_index.setter  # type: ignore
     def key_column_index(self, value: Optional[int]):
         columns = self.columns
         if self.key_column_index is not None:
             old_column = columns[self.key_column_index]
-            old_column.column_type = TABLE_COLUMN_TYPES.METADATA
+            old_column['column_type'] = TABLE_COLUMN_TYPES.METADATA
 
-            self.columns = columns  # update the json representation
             db.session.add(self)
-
-            # this will likely not be needed as most of the request local
-            # caching will be unnecessary
-            clear_cache()
 
         if value is not None:
             new_column = columns[value]
-            new_column.column_type = TABLE_COLUMN_TYPES.INDEX
+            new_column['column_type'] = TABLE_COLUMN_TYPES.INDEX
 
-            self.columns = columns  # update the json representation
             db.session.add(self)
 
-            clear_cache()
-
-    # update group_column_index like above
-    @hybrid_property
+    @property
     def group_column_index(self):
-        return _group_column_index(self)
-
-    @group_column_index.expression  # type: ignore
-    def group_column_index(cls):  # noqa: N805
-        return TableColumn.query\
-            .filter_by(csv_file_id=cls.id, column_type=TABLE_COLUMN_TYPES.GROUP)\
-            .with_entities(TableColumn.column_index)\
-            .scalar()
+        column = self.find_first_entity(
+            lambda c: c['column_type'] == TABLE_COLUMN_TYPES.GROUP, self.columns)
+        return column and column['column_index']
 
     @group_column_index.setter  # type: ignore
     def group_column_index(self, value: Optional[int]):
+        columns = self.columns
         if self.group_column_index is not None:
-            old_column = self.columns[self.group_column_index]
-            old_column.column_type = TABLE_COLUMN_TYPES.METADATA
-            db.session.add(old_column)
-            clear_cache()
+            old_column = columns[self.group_column_index]
+            old_column['column_type'] = TABLE_COLUMN_TYPES.METADATA
+
+            db.session.add(self)
+
             self.group_levels = []
 
         if value is not None:
-            new_column = self.columns[value]
-            new_column.column_type = TABLE_COLUMN_TYPES.GROUP
-            db.session.add(new_column)
-            self.derive_group_levels()
-            clear_cache()
+            new_column = columns[value]
+            new_column['column_type'] = TABLE_COLUMN_TYPES.GROUP
 
-    def derive_group_levels(self, clear_caches=False):
-        if clear_caches:
-            clear_cache(csv_file=self)
+            db.session.add(self)
+
+            self.derive_group_levels()
+
+    def derive_group_levels(self):
         groups = self.groups
         if groups is None or groups.empty:
             self.group_levels = []
@@ -294,20 +321,54 @@ class CSVFile(BaseModel):
 
     @property
     def keys(self):
-        return _keys(self)
+        return self._keys()
+
+    def _keys(self, key_column_index=None):
+        idx = self.key_column_index or key_column_index
+        if idx is None:
+            return [
+                f'row{i + 1}' for i in range(self.table.shape[0])
+            ]
+        return list(self.table.iloc[:, idx])
 
     def filter_table_by_types(self, row_type, column_type):
-        return _filter_table_by_types(self, row_type, column_type)
+        if self.header_row_index is None or \
+                self.key_column_index is None:
+            return None
+        rows = [
+            row['row_index'] for row in self.rows
+            if row['row_type'] == row_type
+        ]
+        if self.header_row_index is not None:
+            rows = [self.header_row_index] + rows
+        else:
+            current_app.logger.warning('No header row is set.')
+
+        columns = [
+            column['column_index'] for column in self.columns
+            if column['column_type'] == column_type
+        ]
+        if self.key_column_index is not None:
+            index_col = 0
+            columns = [self.key_column_index] + columns
+        else:
+            index_col = None
+
+        return pandas.read_csv(
+            BytesIO(
+                self.table.iloc[rows, columns].to_csv(header=False, index=False).encode()
+            ), index_col=index_col
+        )
 
     @property
     def missing_cells(self) -> List[Tuple[int, int]]:
-        table = _coerce_numeric(self.raw_measurement_table)
+        table = self._coerce_numeric()
         col, row = numpy.nonzero(table.isna().to_numpy())
         return numpy.column_stack((row, col)).astype(int).tolist()
 
     def apply_transforms(self) -> pandas.DataFrame:
         table = self.raw_measurement_table
-        table = _coerce_numeric(table)
+        table = self._coerce_numeric()
         return impute_missing(table, self.groups,
                               mnar=self.imputation_mnar, mcar=self.imputation_mcar)
 
@@ -319,7 +380,8 @@ class CSVFile(BaseModel):
 
     @property
     def _stats(self):
-        return _get_csv_file_stats(self)
+        if self.raw_measurement_table is not None:
+            return self._get_table_stats()
 
     @classmethod
     def create_csv_file(cls, id: str, name: str, table: str, **kwargs):
@@ -327,10 +389,9 @@ class CSVFile(BaseModel):
         cls._save_csv_file_data(csv_file.uri, table)
         row_types, column_types = _guess_table_structure(csv_file.table)
 
-        # TODO: get from row_types list
-        header_row_index = 0
-        headers = _headers(csv_file, header_row_index)
-        columns: List[TableColumn] = []
+        header_row_index = row_types.index(TABLE_ROW_TYPES.INDEX)
+        headers = csv_file._headers(header_row_index)
+        columns = []
         last_data_column_index = 0
         for index, column_type in enumerate(column_types):
             data_column_index = None
@@ -338,26 +399,40 @@ class CSVFile(BaseModel):
                 last_data_column_index += 1
                 data_column_index = last_data_column_index
 
-            columns.append(TableColumn(
-                csv_file=csv_file,
-                column_index=index,
-                column_type=column_type,
-                data_column_index=data_column_index,
-                column_header=headers[index],
-            ))
+            columns.append({
+                'meta': {},
+                'subtype': None,
+                'column_index': index,
+                'column_type': column_type,
+                'column_header': headers[index],
+                'data_column_index': data_column_index
+            })
 
         # do something similar for the rows
-        rows: List[TableRow] = []
-        table_row_schema = TableRowSchema()
+        key_column_index = column_types.index(TABLE_COLUMN_TYPES.INDEX)
+        keys = csv_file._keys(key_column_index)
+        rows = []
+        last_data_row_index = 0
         for index, row_type in enumerate(row_types):
-            rows.append(table_row_schema.load({
-                'csv_file_id': id, 'row_index': index, 'row_type': row_type
-            }))
+            data_row_index = None
+            if row_type == TABLE_ROW_TYPES.DATA:
+                last_data_row_index += 1
+                data_row_index = last_data_row_index
+            rows.append({
+                'meta': {},
+                'subtype': None,
+                'row_index': index,
+                'row_type': row_type,
+                'row_name': keys[index],
+                'data_row_index': data_row_index
+            })
 
-        csv_file.rows = rows
-        csv_file.columns = columns
+        table_column_schema = TableColumnSchema()
+        csv_file.column_json = table_column_schema.dump(columns, many=True)
+        table_row_schema = TableRowSchema()
+        csv_file.row_json = table_row_schema.dump(rows, many=True)
+
         csv_file.derive_group_levels()
-
         return csv_file, rows, columns
 
     @classmethod
@@ -365,14 +440,13 @@ class CSVFile(BaseModel):
         uri.parent.mkdir(parents=True, exist_ok=True)
         with open(uri, 'w') as f:
             f.write(table_data)
-        clear_cache()
         return table_data
 
     def get_column_by_name(self, column_name: str):
-        return self.find_first_entity(lambda c: c.column_header == column_name, self.columns)
+        return self.find_first_entity(lambda c: c['column_header'] == column_name, self.columns)
 
     def get_row_by_name(self, row_name):
-        return self.find_first_entity(lambda r: r.row_name == row_name, self.rows)
+        return self.find_first_entity(lambda r: r['row_name'] == row_name, self.rows)
 
     @classmethod
     def find_first_entity(cls, criterion: Callable[[T], bool],
@@ -381,6 +455,47 @@ class CSVFile(BaseModel):
             if criterion(entity):
                 return entity
         return None
+
+    def _get_table_stats(self):
+        table = self.raw_measurement_table
+        # Get global stats all once because it is more efficient than
+        # doing it per row/column.
+
+        # Once validation is done on indices we can get variance with:
+        #   table.var(axis=?).to_list()
+        # for now we need to do it per row/column
+        def get_variance(series):
+            return pandas.to_numeric(series, errors='coerce').var()
+
+        def get_nan(series):
+            s = pandas.to_numeric(series, errors='coerce')
+            return (s != s).sum() / s.shape[0]
+
+        column_missing = [get_nan(table.iloc[:, i]) for i in range(table.shape[1])]
+        column_variance = [get_variance(table.iloc[:, i]) for i in range(table.shape[1])]
+        row_missing = [get_nan(table.iloc[i, :]) for i in range(table.shape[0])]
+        row_variance = [get_variance(table.iloc[i, :]) for i in range(table.shape[0])]
+        return {
+            'columns': {
+                'missing': column_missing,
+                'variance': column_variance
+            },
+            'rows': {
+                'missing': row_missing,
+                'variance': row_variance
+            }
+        }
+
+    def _coerce_numeric(self) -> pandas.DataFrame:
+        """Coerce a table into numeric values."""
+        table = self.raw_measurement_table
+        for i in range(table.shape[1]):
+            table.iloc[:, i] = pandas.to_numeric(table.iloc[:, i], errors='coerce')
+        return table
+
+    def _get_csv_file_stats(self):
+        if self.raw_measurement_table is not None:
+            return self._get_table_stats()
 
 
 def _validate_table_data(table: str):
@@ -401,8 +516,8 @@ class CSVFileSchema(BaseSchema):
         missing='random-forest', validate=validate.OneOf(IMPUTE_MCAR_METHODS))
     meta = fields.Dict(missing=dict)
 
-    columns = fields.List(fields.Nested('TableColumnSchema', exclude=['csv_file']))
-    rows = fields.List(fields.Nested('TableRowSchema', exclude=['csv_file']))
+    columns = fields.List(fields.Nested('TableColumnSchema'))
+    rows = fields.List(fields.Nested('TableRowSchema'))
 
     selected_columns = fields.List(fields.Str(), dump_only=True, missing=list)
     group_levels = fields.List(fields.Nested('GroupLevelSchema'))
@@ -424,7 +539,6 @@ class CSVFileSchema(BaseSchema):
     def read_csv_file(self, data, **kwargs):
         if 'table' not in data:
             return data
-
         data['table'] = data['table'].to_csv(header=False, index=False)
         if data.get('measurement_table') is not None:
             data['measurement_table'] = clean(data['measurement_table']).to_dict(
@@ -435,7 +549,6 @@ class CSVFileSchema(BaseSchema):
     def make_object(self, data, **kwargs):
         csv_file, rows, columns = CSVFile.create_csv_file(**data)
         db.session.add(csv_file)
-        db.session.add_all(rows + columns)
         return csv_file
 
 
@@ -454,25 +567,7 @@ class SampleGroupSchema(BaseSchema):
     files = fields.List(fields.Nested(CSVFileSchema, only=['id', 'name', 'description']))
 
 
-# replace TableColumn model with something like this (similar for TableRow)
-@dataclass
-class TableColumn:
-    csv_file: CSVFile
-
-    # index into the raw csv file
-    column_index: int
-    column_type: str
-    subtype: Optional[str]
-    meta: Dict[str, Any]
-
-    # index into the sample table
-    data_column_index: Optional[int]
-    column_header: str
-
-
 class TableColumnSchema(BaseSchema):
-    __model__ = TableColumn  # type: ignore
-
     csv_file_id = fields.UUID(required=True, load_only=True)
     column_header = fields.Str(dump_only=True)
     column_index = fields.Int(required=True, validate=validate.Range(min=0))
@@ -480,54 +575,14 @@ class TableColumnSchema(BaseSchema):
     subtype = fields.Str(required=False, validate=validate.OneOf(METADATA_TYPES))
     meta = fields.Dict(missing=dict)
 
-    csv_file = fields.Nested(
-        CSVFileSchema, exclude=['rows', 'columns'], dump_only=True)
-
-
-class TableRow(BaseModel):
-    csv_file_id = db.Column(
-        UUIDType(binary=False), db.ForeignKey('csv_file.id'), primary_key=True)
-    row_index = db.Column(db.Integer, primary_key=True)
-    row_type = db.Column(db.String, nullable=False)
-    subtype = db.Column(db.String, nullable=True)
-    meta = db.Column(JSONType, nullable=True)
-
-    csv_file = db.relationship(
-        CSVFile, backref=db.backref('rows', lazy=True, order_by='TableRow.row_index'))
-
-    @property
-    def row_name(self):
-        return self.csv_file.keys[self.row_index]
-
-    @property
-    def data_row_index(self):
-        return _data_row_index(self)
-
-    @property
-    def missing_percent(self) -> Optional[float]:
-        if self.row_type == TABLE_ROW_TYPES.DATA:
-            return self.csv_file._stats['rows']['missing'][self.data_row_index]
-        return None
-
-    @property
-    def data_variance(self) -> Optional[float]:
-        if self.row_type == TABLE_ROW_TYPES.DATA:
-            return self.csv_file._stats['rows']['variance'][self.data_row_index]
-        return None
-
 
 class TableRowSchema(BaseSchema):
-    __model__ = TableRow  # type: ignore
-
     csv_file_id = fields.UUID(required=True, load_only=True)
     row_name = fields.Str(dump_only=True)
     row_index = fields.Int(required=True, validate=validate.Range(min=0))
     row_type = fields.Str(required=True, validate=validate.OneOf(TABLE_ROW_TYPES))
     subtype = fields.Str(required=False, validate=validate.OneOf(METADATA_TYPES))
     meta = fields.Dict(missing=dict)
-
-    csv_file = fields.Nested(
-        CSVFileSchema, exclude=['rows', 'columns'], dump_only=True)
 
 
 class ModifyLabelChangesSchema(Schema):
@@ -551,216 +606,6 @@ class ModifyLabelChangesSchema(Schema):
 
 class ModifyLabelListSchema(Schema):
     changes = fields.List(fields.Nested(ModifyLabelChangesSchema), required=True)
-
-
-listen(CSVFile, 'after_update', lambda mapper, connection, target: clear_cache(csv_file=target))
-listen(TableRow, 'after_update',
-       lambda mapper, connection, target: clear_cache(csv_file=target.csv_file))
-listen(TableColumn, 'after_update',
-       lambda mapper, connection, target: clear_cache(csv_file=target.csv_file))
-
-
-# Cached class method implementations:
-# These are placed here because dogpile does not allow you
-# to include the class instance in the cache key.  :'(
-@region.cache_on_arguments()
-def _read_csv_file(path: str, **kwargs):
-    return pandas.read_csv(path, **kwargs)
-
-
-@region.cache_on_arguments()
-def _header_row_index(csv_file: CSVFile) -> Optional[int]:
-    row = csv_file.find_first_entity(lambda r: r.row_type == TABLE_ROW_TYPES.INDEX, csv_file.rows)
-    return row and row.row_index
-
-
-@region.cache_on_arguments()
-def _headers(csv_file: CSVFile, header_row_index=None) -> List[str]:
-    idx = header_row_index or csv_file.header_row_index
-    if idx is None:
-        return [
-            f'col{i + 1}' for i in range(csv_file.table.shape[1])
-        ]
-
-    return list(csv_file.table.iloc[idx, :])
-
-
-@region.cache_on_arguments()
-def _group_column_index(csv_file: CSVFile) -> Optional[int]:
-    column = csv_file.find_first_entity(
-        lambda c: c.column_type == TABLE_COLUMN_TYPES.GROUP, csv_file.columns)
-    return column and column.column_index
-
-
-@region.cache_on_arguments()
-def _keys(csv_file: CSVFile) -> List[str]:
-    idx = csv_file.key_column_index
-    if idx is None:
-        return [
-            f'row{i + 1}' for i in range(csv_file.table.shape[0])
-        ]
-
-    return list(csv_file.table.iloc[:, idx])
-
-
-@region.cache_on_arguments()
-def _get_table_stats(table: pandas.DataFrame):
-    # Get global stats all once because it is more efficient than
-    # doing it per row/column.
-
-    # Once validation is done on indices we can get variance with:
-    #   table.var(axis=?).to_list()
-    # for now we need to do it per row/column
-    def get_variance(series):
-        return pandas.to_numeric(series, errors='coerce').var()
-
-    def get_nan(series):
-        s = pandas.to_numeric(series, errors='coerce')
-        return (s != s).sum() / s.shape[0]
-
-    column_missing = [get_nan(table.iloc[:, i]) for i in range(table.shape[1])]
-    column_variance = [get_variance(table.iloc[:, i]) for i in range(table.shape[1])]
-    row_missing = [get_nan(table.iloc[i, :]) for i in range(table.shape[0])]
-    row_variance = [get_variance(table.iloc[i, :]) for i in range(table.shape[0])]
-    return {
-        'columns': {
-            'missing': column_missing,
-            'variance': column_variance
-        },
-        'rows': {
-            'missing': row_missing,
-            'variance': row_variance
-        }
-    }
-
-
-@region.cache_on_arguments()
-def _filter_table_by_types(csv_file: CSVFile, row_type: str,
-                           column_type: str) -> Optional[pandas.DataFrame]:
-    if csv_file.header_row_index is None or \
-            csv_file.key_column_index is None:
-        return None
-    rows = [
-        row.row_index for row in csv_file.rows
-        if row.row_type == row_type
-    ]
-    if csv_file.header_row_index is not None:
-        rows = [csv_file.header_row_index] + rows
-    else:
-        current_app.logger.warning('No header row is set.')
-
-    columns = [
-        column.column_index for column in csv_file.columns
-        if column.column_type == column_type
-    ]
-    if csv_file.key_column_index is not None:
-        index_col = 0
-        columns = [csv_file.key_column_index] + columns
-    else:
-        index_col = None
-
-    return pandas.read_csv(
-        BytesIO(
-            csv_file.table.iloc[rows, columns].to_csv(header=False, index=False).encode()
-        ), index_col=index_col
-    )
-
-
-@region.cache_on_arguments()
-def _indexed_table(csv_file: CSVFile) -> pandas.DataFrame:
-    kwargs: Dict[str, Any] = {}
-
-    # handle column names
-    header_row = csv_file.header_row_index
-    kwargs['header'] = header_row
-    if header_row is None:
-        kwargs['names'] = csv_file.headers
-
-    # handle row ids
-    kwargs['index_col'] = False
-    key_column = csv_file.key_column_index
-    if key_column is not None:
-        kwargs['index_col'] = key_column
-
-    indexed_table = _read_csv_file(csv_file.uri, **kwargs)
-
-    # inject the computed keys in case the csv file does not have a primary key column
-    if key_column is None:
-        keys = csv_file.keys
-
-        # exclude the header row from the primary key index if present
-        if header_row is not None:
-            keys = keys[1:]
-        indexed_table.index = pandas.Index(keys)
-
-    return indexed_table
-
-
-@region.cache_on_arguments()
-def _data_row_index(row: TableRow) -> Optional[int]:
-    """Return the index in the measurement table or None if not a data row."""
-    if row.row_type != TABLE_ROW_TYPES.DATA:
-        return None
-    query = row.query.filter_by(csv_file_id=row.csv_file_id, row_type=TABLE_ROW_TYPES.DATA)
-    return query.filter(TableRow.row_index < row.row_index).count()
-
-
-@region.cache_on_arguments()
-def _data_column_index(column: TableColumn) -> Optional[int]:
-    """Return the index in the measurement table or None if not a data column."""
-    if column.column_type != TABLE_COLUMN_TYPES.DATA:
-        return None
-    query = column.query.filter_by(
-        csv_file_id=column.csv_file_id, column_type=TABLE_COLUMN_TYPES.DATA)
-    return query.filter(TableColumn.column_index < column.column_index).count()
-
-
-@region.cache_on_arguments()
-def _coerce_numeric(table: pandas.DataFrame) -> pandas.DataFrame:
-    """Coerce a table into numeric values."""
-    for i in range(table.shape[1]):
-        table.iloc[:, i] = pandas.to_numeric(table.iloc[:, i], errors='coerce')
-    return table
-
-
-# The following methods are stored in a persistent cache (memcached) if configured.
-# They are for more complicated functions that could take significant time to execute
-# and are commonly called between multiple rest endpoints with the same value.
-def _get_raw_measurement_table(csv_file: CSVFile):
-    return csv_file.filter_table_by_types(TABLE_ROW_TYPES.DATA, TABLE_COLUMN_TYPES.DATA)
-
-
-def _get_measurement_table_and_info(csv_file: CSVFile):
-    if not get_fatal_index_errors(csv_file):
-        try:
-            return csv_file.apply_transforms()
-        except Exception as e:
-            # TODO: We should handle this better
-            current_app.logger.exception(e)
-    return None, dict(mcar=[], mnar=[])
-
-
-def _get_measurement_metadata(csv_file: CSVFile) -> pandas.DataFrame:
-    return csv_file.filter_table_by_types(TABLE_ROW_TYPES.METADATA, TABLE_COLUMN_TYPES.DATA)
-
-
-def _get_sample_metadata(csv_file: CSVFile) -> pandas.DataFrame:
-    return csv_file.filter_table_by_types(TABLE_ROW_TYPES.DATA, TABLE_COLUMN_TYPES.METADATA)
-
-
-def _get_groups(csv_file: CSVFile) -> Optional[pandas.DataFrame]:
-    if csv_file.group_column_index is None:
-        return None
-    groups = csv_file.filter_table_by_types(TABLE_ROW_TYPES.DATA, TABLE_COLUMN_TYPES.GROUP)
-    if groups is None:
-        return None
-    # ensure groups are strings
-    return groups.fillna('').astype(str)
-
-
-def _get_csv_file_stats(csv_file: CSVFile):
-    if csv_file.raw_measurement_table is not None:
-        return _get_table_stats(csv_file.raw_measurement_table)
 
 
 class ValidatedMetaboliteTable(BaseModel):

--- a/viime/samples.py
+++ b/viime/samples.py
@@ -5,8 +5,8 @@ from uuid import uuid4
 from sqlalchemy.orm.session import make_transient
 
 from .models import CSVFile, CSVFileSchema, db, GroupLevel, \
-    SampleGroup, SampleGroupSchema, TableColumn, TableRow, \
-    ValidatedMetaboliteTable, ValidatedMetaboliteTableSchema
+    SampleGroup, SampleGroupSchema, ValidatedMetaboliteTable, \
+    ValidatedMetaboliteTableSchema
 
 
 def is_sample_file(csv: CSVFile) -> bool:
@@ -28,10 +28,11 @@ def import_files(files: List[CSVFile]):
         table = csv.table
 
         # remove from session
-        for sub in csv.columns + csv.rows + csv.group_levels:
-            db.session.expunge(sub)
-            make_transient(sub)
-            sub.csv_file_id = new_id
+        for sub in csv.columns + csv.rows:
+            sub['csv_file_id'] = str(new_id)
+
+        for sub in csv.group_levels:
+            sub.csv_file_id = str(new_id)
 
         db.session.expunge(csv)
         make_transient(csv)
@@ -61,8 +62,6 @@ def import_files(files: List[CSVFile]):
             csv.meta['merged'] = new_merged_ids
 
         db.session.add(csv)
-        for sub in csv.columns + csv.rows + csv.group_levels:
-            db.session.add(sub)
 
         imported.append(csv)
 
@@ -164,8 +163,8 @@ def upload(json: Dict[str, Any]):
             validated[key] = json.pop(key)
 
     # remove not auto imported things
-    columns: List[Any] = json.pop('columns', [])
-    rows: List[Any] = json.pop('rows', [])
+    json.pop('columns', [])
+    json.pop('rows', [])
     group_levels: List[Any] = json.pop('group_levels', [])
     sample_group = json.pop('sample_group', None)
     selected_columns = json.pop('selected_columns', [])
@@ -173,20 +172,6 @@ def upload(json: Dict[str, Any]):
         json['description'] = ''
 
     csv = CSVFileSchema().load(json)
-
-    # update types afterwards since the default is auto generated
-
-    def update(acts, templates, model):
-        if not templates:
-            return
-        for act, template in zip(acts, templates):
-            for col in model.__table__.columns.keys():
-                if col in template:
-                    setattr(act, col, template[col])
-            db.session.add(act)
-
-    update(csv.columns, columns, TableColumn)
-    update(csv.rows, rows, TableRow)
 
     if group_levels:
         csv.group_levels = [GroupLevel(**g) for g in group_levels]


### PR DESCRIPTION
@mvandenburgh This is a start of what I had in mind for the refactor.  I only made a few of the modifications for the column information, but tried to add comments where there are similar changes need to happen elsewhere.

The changes here are designed to provide as close as possible to a compatible interface to the ORM classes.  This should help minimize the number of changes required to getting a working version of the refactored codebase.  For performance concerns, we may ultimately want to make more invasive changes, but that can wait until later.

Feel free to start from this branch, or just use it as a guide.  I can also add in more comments explaining what is going on if that would help.