### PR TITLE
Fix LoadingsPlot

### DIFF
--- a/web/src/components/vis/LoadingsPlot.vue
+++ b/web/src/components/vis/LoadingsPlot.vue
@@ -146,7 +146,9 @@ export default {
         showCrosshairs,
       } = this;
 
-      if (pointsInternal.length === 0) {
+      if (pointsInternal.length === 0
+        || pointsInternal[0].loadings.length < pcX
+        || pointsInternal[0].loadings.length < pcY) {
         return;
       }
 


### PR DESCRIPTION
`LoadingsPlot.vue` takes two arguments, the index of the PC to use for
the X and Y axes. If this index is out of bounds for the available data,
it would noisily fail to render the SVG. That is now fixed.