### PR TITLE
Fix Heatmap console errors

### DIFF
--- a/web/src/components/vis/Heatmap.vue
+++ b/web/src/components/vis/Heatmap.vue
@@ -281,8 +281,8 @@ export default {
       return this.rowConfig.dendrogram ? this.width * DENDROGRAM_RATIO : 0;
     },
     matrixDimensions() {
-      let width = this.width - this.rowDendrogramWidth - LABEL_WIDTH;
-      let height = this.height - this.columnDendrogramHeight - LABEL_WIDTH;
+      let width = Math.max(this.width - this.rowDendrogramWidth - LABEL_WIDTH, 0);
+      let height = Math.max(this.height - this.columnDendrogramHeight - LABEL_WIDTH, 0);
       if (this.layout === 'squareCells') {
         const wx = width / this.columnLeaves.length;
         const hy = height / this.rowLeaves.length;

--- a/web/src/store/index.js
+++ b/web/src/store/index.js
@@ -489,7 +489,7 @@ const actions = {
           commit(SET_LOADING, false);
           commit(SET_PLOT, { dataset_id, name, obj: { loading: false, data: d, valid: true } });
         } catch (err) {
-          commit(SET_PLOT, { dataset_id, name, obj: { loading: false, valid: false } });
+          commit(SET_PLOT, { dataset_id, name, obj: { loading: false, valid: true } });
           commit(SET_LOADING, err);
           throw err;
         }


### PR DESCRIPTION
`Heatmap.vue` generated some errors during normal usage. These are now
fixed.

- When first loading the page, the default width/height (0) had the
margin and the dendrogram width/height subtracted from them, which
resulted in an initally negative width/height. This caused an SVG
rendering error.
- Deselecting all of the `Metabolite Filter` options or all of the
`Sample Filter` options resulted in a 400 error. This is expected, but
the error was handled incorrectly and locked up the UI; the only way to
get interactivity back was to reload the page.