### PR TITLE
Fix filter node bugs

### DIFF
--- a/web/src/components/vis/CorrelationTile.vue
+++ b/web/src/components/vis/CorrelationTile.vue
@@ -157,6 +157,8 @@ vis-tile-large.correlation(v-if="plot", title="Correlation Network", :loading="p
               @change="changePlotArgs({min_correlation: $event})")
     metabolite-filter(title="Node Filter", :dataset="dataset", v-model="metaboliteFilter",
         :not-selected-color="colors.correlationNode", selection-last)
+    metabolite-colorer(title="Node Color", :dataset="dataset", v-model="metaboliteColor",
+        :not-selected-color="colors.correlationNode", selection-last)
 
     v-toolbar.darken-3(color="primary", dark, flat, dense, :card="false")
       v-toolbar-title Search

--- a/web/src/components/vis/ForceDirectedGraph.vue
+++ b/web/src/components/vis/ForceDirectedGraph.vue
@@ -105,7 +105,7 @@ export default {
     search(searchedNodes) {
       // highlights nodes being searched for
       const nodes = select(this.$refs.svg).select('g.nodes').selectAll('g');
-      nodes.select('circle').style('fill', (d) => (searchedNodes.includes(d.id) ? 'red' : d.color));
+      nodes.select('circle').style('fill', (node, index) => (searchedNodes.includes(node.id) ? 'red' : this.nodes[index].color));
       this.showNodesWithinPathLength(this.search, this.visibleNodes);
     },
     highlightedItems(highlightedItems) {
@@ -119,12 +119,21 @@ export default {
       const nodes = select(this.$refs.svg).select('g.nodes').selectAll('g').select('circle');
       const edges = select(this.$refs.svg).select('g.edges').selectAll('g').select('line');
       // hide nodes that have been deleted from search results
-      nodes.style('visibility', (node) => (excluded.has(node.id) ? 'hidden' : ''));
+      nodes.style('visibility', (node) => (excluded.has(node.id) ? 'hidden' : 'visible'));
       edges.style('visibility', (edge) => (excluded.has(edge.source.id) || excluded.has(edge.target.id) ? 'hidden' : 'visible'));
       this.showNodesWithinPathLength(this.search, this.visibleNodes);
     },
     visibleNodes(visibleNodes) {
       this.showNodesWithinPathLength(this.search, visibleNodes);
+    },
+    nodes(newNodes) {
+      // hide/unhide nodes based on node filter
+      const newNodeSet = new Set(newNodes.map((node) => node.id)); // convert to set for fast lookup
+      const nodes = select(this.$refs.svg).select('g.nodes').selectAll('g').select('circle');
+      const edges = select(this.$refs.svg).select('g.edges').selectAll('g').select('line');
+      nodes.style('visibility', (node) => (newNodeSet.has(node.id) ? 'visible' : 'hidden'))
+           .style('fill', (node, index) => (this.search.includes(node.id) ? 'red' : this.nodes[index].color));
+      edges.style('visibility', (edge) => (newNodeSet.has(edge.source.id) && newNodeSet.has(edge.target.id) ? 'visible' : 'hidden'));
     },
   },
   mounted() {
@@ -387,7 +396,7 @@ export default {
       nodes.style('visibility', (node) => (
         (
           visibleNodes.has(node.id) && !this.excludedItems.has(node.id)
-        ) ? '' : 'hidden'));
+        ) ? 'visible' : 'hidden'));
       edges.style('visibility', (edge) => ((
         (
           visibleEdges[edge.source.id].has(edge.target.id)
@@ -395,7 +404,7 @@ export default {
         )
         && !this.excludedItems.has(edge.source.id)
         && !this.excludedItems.has(edge.target.id)
-      ) ? '' : 'hidden'));
+      ) ? 'visible' : 'hidden'));
     },
   },
 };

--- a/web/src/components/vis/ForceDirectedGraph.vue
+++ b/web/src/components/vis/ForceDirectedGraph.vue
@@ -103,16 +103,16 @@ export default {
   },
   watch: {
     search(searchedNodes) {
-      // highlights nodes being searched for
-      const nodes = select(this.$refs.svg).select('g.nodes').selectAll('g');
-      nodes.select('circle').style('fill', (node, index) => (searchedNodes.includes(node.id) ? 'red' : this.nodes[index].color));
+      // circles nodes being searched for
+      const nodes = select(this.$refs.svg).select('g.nodes').selectAll('g').select('circle');
+      nodes.style('stroke', (node) => (searchedNodes.includes(node.id) ? 'red' : ''))
+        .style('stroke-width', (node) => (searchedNodes.includes(node.id) ? '2' : '1'));
       this.showNodesWithinPathLength(this.search, this.visibleNodes);
     },
     highlightedItems(highlightedItems) {
-      // circles nodes in search results
+      // highlights nodes in search results
       const nodes = select(this.$refs.svg).select('g.nodes').selectAll('g').select('circle');
-      nodes.style('stroke', (d) => (highlightedItems.has(d.id) ? 'red' : d.color));
-      nodes.style('stroke-width', (d) => (highlightedItems.has(d.id) ? '2' : '1'));
+      nodes.style('fill', (node, index) => (highlightedItems.has(node.id) ? 'red' : this.nodes[index].color));
     },
     excludedItems(excluded) {
       // circles nodes in search results
@@ -132,7 +132,7 @@ export default {
       const nodes = select(this.$refs.svg).select('g.nodes').selectAll('g').select('circle');
       const edges = select(this.$refs.svg).select('g.edges').selectAll('g').select('line');
       nodes.style('visibility', (node) => (newNodeSet.has(node.id) ? 'visible' : 'hidden'))
-           .style('fill', (node, index) => (this.search.includes(node.id) ? 'red' : this.nodes[index].color));
+        .style('fill', (node, index) => (this.highlightedItems.has(node.id) ? 'red' : this.nodes[index].color));
       edges.style('visibility', (edge) => (newNodeSet.has(edge.source.id) && newNodeSet.has(edge.target.id) ? 'visible' : 'hidden'));
     },
   },
@@ -309,7 +309,9 @@ export default {
 
       nodes.select('circle')
         .attr('r', this.radius)
-        .style('fill', (d) => (this.search.includes(d.id) ? 'red' : d.color))
+        .style('fill', (d) => d.color)
+        .style('stroke', (d) => (this.search.includes(d.id) ? 'red' : ''))
+        .style('stroke-width', (d) => (this.search.includes(d.id) ? '2' : '1'))
         .on('click', resetPinned)
         .call(drag()
           .container(function container() {


### PR DESCRIPTION
This fixes two bugs on viime.org now - the "Filter Node" dialog box does not work, and "selected" nodes are not highlighted in orange as they should be.