### PR TITLE
Fix Heatmap mousemove out of bounds errors

### DIFF
--- a/web/src/components/vis/Heatmap.vue
+++ b/web/src/components/vis/Heatmap.vue
@@ -548,8 +548,9 @@ export default {
       const w = canvas.width / this.columnLeaves.length;
       const h = canvas.height / this.rowLeaves.length;
 
-      const j = Math.floor(evt.offsetX / w);
-      const i = Math.floor(evt.offsetY / h);
+      const j = Math.floor(Math.max(evt.offsetX, 0) / w);
+      const i = Math.floor(Math.max(evt.offsetY, 0) / h);
+
       const rnode = this.rowLeaves[i].data;
       const cnode = this.columnLeaves[j].data;
       const rowChanged = changeHovered(this.row, rnode.indices);


### PR DESCRIPTION
For some reason, the `canvasMouseMove` event handler in `Heatmap.vue`
was firing with `offsetX` and `offsetY` values of `-1` when the mouse
was just barely out of bounds, instead of not firing an event at all.

The fix is to round up to 0 in those cases.

fixes https://sentry.io/organizations/kitware-data/issues/1627337144/activity/?project=1814179&query=is%3Aunresolved&statsPeriod=30d