### PR TITLE
Fix chips extending past search box

### DIFF
--- a/web/src/components/vis/CorrelationTile.vue
+++ b/web/src/components/vis/CorrelationTile.vue
@@ -184,10 +184,13 @@ vis-tile-large.correlation(v-if="plot", title="Correlation Network", :loading="p
                 | mdi-eye-off
               span {{ data.item }}
           template(v-slot:selection="data")
-            v-chip(small)
-              v-icon.closePillButton.pr-1(small,
-                  @click.stop="unselect(data.item)")
-                | mdi-close
+            v-tooltip(right)
+              template(v-slot:activator="{ on, attrs }")
+                v-chip(small, v-on="on")
+                  v-icon.closePillButton.pr-1(small,
+                      @click.stop="unselect(data.item)")
+                    | mdi-close
+                  span.searchResult {{ data.item }}
               span {{ data.item }}
       v-btn.my-0.mx-0.mt-2(small, flat, @click="clearSearch")
         v-icon.pr-2 mdi-close
@@ -226,6 +229,12 @@ vis-tile-large.correlation(v-if="plot", title="Correlation Network", :loading="p
 </template>
 
 <style scoped>
+.searchResult {
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  width: 100px;
+}
 .closePillButton:hover {
   color: red;
 }

--- a/web/src/components/vis/VisTileLarge.vue
+++ b/web/src/components/vis/VisTileLarge.vue
@@ -46,7 +46,7 @@ export default {
 v-layout(v-else, row, fill-height)
   v-navigation-drawer.primary.darken-3.nav-drawer(
       v-if="hasControls", permanent,
-      style="width: 200px;min-width: 200px;",
+      style="width: 215px;min-width: 215px;",
       touchless, disable-resize-watcher, stateless)
     slot(name="controls")
 


### PR DESCRIPTION
I attempted to fix the chip overflow issue by widening the control panel slightly and shortening the searched nodes' names with ellipsis, with the full name displayed as a tooltip when hovered over. See below -
![2anHkCyKb6](https://user-images.githubusercontent.com/37340715/84947327-086c2e80-b0b8-11ea-97d7-dd7413650f76.gif)