### PR TITLE
Fix help icons not being right aligned

### DIFF
--- a/web/src/components/toolbar/HelpDialog.vue
+++ b/web/src/components/toolbar/HelpDialog.vue
@@ -25,7 +25,7 @@ export default {
 <template lang="pug">
 v-dialog(v-model="showHelp", max-width="33vw")
   template(v-slot:activator="{ on }")
-    v-btn.ma-0(v-on="on", icon, small, depressed, flat)
+    v-btn.ml-auto.mr-0(v-on="on", icon, small, depressed, flat)
       v-icon(:color="outline ? 'rgba(0,0,0,0.25)' : undefined", small)
         | {{ outline ? $vuetify.icons.helpOutline : $vuetify.icons.help }}
   v-card

--- a/web/src/components/toolbar/ToolbarOption.vue
+++ b/web/src/components/toolbar/ToolbarOption.vue
@@ -61,5 +61,13 @@ div
 .wide >>> .v-label {
   flex: 1 1 0;
 }
+</style>
 
+<style>
+/* This fixes a bug that was fixed in Vuetify 2.1 */
+/* See https://github.com/vuetifyjs/vuetify/issues/5416#issuecomment-567106519 */
+/* TODO Remove this once the version is bumped */
+.v-input--selection-controls .v-input__control {
+  width: 100% !important;
+}
 </style>


### PR DESCRIPTION
The help icons in the toolbar menus that display a tooltip when clicked
were overlapping with the radio button text rather than being right
aligned.

There is a bug introduced in Vuetify 1.3 and fixed in 2.1 that prevented
them from being alignable. There is a hack that needs to be removed when
the vuetify version is bumped.