### PR TITLE
Use TypeScript in LoadingsPlot

### DIFF
--- a/web/src/components/vis/BoxPlot.vue
+++ b/web/src/components/vis/BoxPlot.vue
@@ -70,7 +70,12 @@ export default defineComponent({
       dwidth,
       dheight,
       axisPlot,
-    } = useAxisPlot({ margin, width, height, topAxis: true });
+    } = useAxisPlot({
+      margin,
+      width,
+      height,
+      topAxis: true,
+    });
 
     const xrange = computed(() => {
       if (props.groups.length) {

--- a/web/src/components/vis/BoxPlot.vue
+++ b/web/src/components/vis/BoxPlot.vue
@@ -70,7 +70,7 @@ export default defineComponent({
       dwidth,
       dheight,
       axisPlot,
-    } = useAxisPlot(margin, width, height);
+    } = useAxisPlot({ margin, width, height, topAxis: true });
 
     const xrange = computed(() => {
       if (props.groups.length) {
@@ -250,7 +250,7 @@ export default defineComponent({
 
 <style scoped>
 .boxplot {
-  transition: .4s ease-in-out;
+  transition: 0.4s ease-in-out;
 }
 .axes >>> text {
   font-size: 14px;

--- a/web/src/components/vis/use/useAxisPlot.ts
+++ b/web/src/components/vis/use/useAxisPlot.ts
@@ -29,7 +29,19 @@ interface Margin {
 }
 
 export default function useAxisPlot(
-  { margin, width, height, duration = 500, topAxis = false }: { margin: Margin, width: Ref<number>, height: Ref<number>, duration?: number, topAxis?: Boolean }
+  {
+    margin,
+    width,
+    height,
+    duration = 500,
+    topAxis = false,
+  }: {
+    margin: Margin;
+    width: Ref<number>;
+    height: Ref<number>;
+    duration?: number;
+    topAxis?: boolean;
+  },
 ) {
   const data = reactive({
     axisPlotInitialized: false,

--- a/web/src/components/vis/use/useAxisPlot.ts
+++ b/web/src/components/vis/use/useAxisPlot.ts
@@ -29,7 +29,7 @@ interface Margin {
 }
 
 export default function useAxisPlot(
-  margin: Margin, width: Ref<number>, height: Ref<number>, duration = 500,
+  { margin, width, height, duration = 500, topAxis = false }: { margin: Margin, width: Ref<number>, height: Ref<number>, duration?: number, topAxis?: Boolean }
 ) {
   const data = reactive({
     axisPlotInitialized: false,
@@ -44,13 +44,17 @@ export default function useAxisPlot(
     const master = svg.select('g.master').attr('transform', `translate(${margin.left},${margin.top})`);
     const axes = master.select('g.axes');
 
+    const xAxisOffset = (topAxis) ? 0 : dheight.value;
+
     if (axes.select('.x-axis').size() === 0) {
       axes.append('g')
         .classed('x-axis', true)
+        .attr('transform', `translate(0,${xAxisOffset})`)
         .call(axisX);
     } else {
       axes.select('.x-axis')
         .transition()
+        .attr('transform', `translate(0,${xAxisOffset})`)
         .duration(duration)
         .call(axisX);
     }
@@ -79,7 +83,6 @@ export default function useAxisPlot(
     if (!svg.node()) {
       return;
     }
-
     labelAxis(svg.select('.label.x'),
       msg,
       (bbox: DOMRect) => dwidth.value / 2 - bbox.width / 2,

--- a/web/src/store/index.js
+++ b/web/src/store/index.js
@@ -91,7 +91,7 @@ const plotDefaults = {
     type: plot_types.TRANSFORM,
   },
   loadings: {
-    data: null,
+    data: [],
     valid: false,
     loading: false,
     args: {},


### PR DESCRIPTION
Following the example of BoxPlot, update LoadingsPlot to use Typescript.

There was an attempt to move the rendering from D3 into Vue, but that
was stymied by some strange event handling around mouseover tooltips.
For now LoadingsPlot is still using the same rendering code as always.

There was also a small bug where the X axis was being rendered at the
top of the plot instead of the bottom.

This PR is waiting on https://github.com/girder/viime/pull/565 for merge cleanliness. I think it's ready for review though.