### PR TITLE
Define environment variables in netlify.toml instead of Netlify UI

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,3 @@
+[build.environment]
+  VUE_APP_GOOGLE_ANALYTICS_ID = "UA-6042509-40"
+  VUE_APP_SERVER_ADDRESS = "https://api.viime.org"


### PR DESCRIPTION
Considering the imminent move to the new Netlify account, I think it might be better to set the environment variables for the web client in a configuration file (described [here](https://docs.netlify.com/configure-builds/file-based-configuration/#configuration-details)) instead of using the Netlify UI to set them. 