### PR TITLE
Catch R errors in ROC analysis

### DIFF
--- a/devops/viime/R/analyses.R
+++ b/devops/viime/R/analyses.R
@@ -249,13 +249,17 @@ factor_analysis <- function(measurements, threshold) {
   #################################
   #-#-#-# Table with Factors #-#-#-#
 
-  # #Loading threshold
-  # lt <- 0.4
-
   #Create table of factors and what is metabolites are in each factor
   OUT=NULL
   for (i in 1:ncomp){
-    a <- which(abs(loadings[,i]) >= threshold) #This is the line that chooses the metabolites with loading higher than 0.4
+    a <- which(abs(loadings[,i]) >= threshold) #This is the line that chooses the metabolites with loading higher than lt
+    if (length(a) == 0) { # if factor analysis returns zero metabolites, return empty dataframe
+      OUT <- data.frame(metabolites <- character(),
+                        eigenvalues <- numeric(),
+                        variances <- numeric(),
+                        factor <- numeric())
+      return(OUT)
+    }
     metabolites <- names(a)
     eigenvalues <- eigen.values[i]
     variances <- Prop.var[i]

--- a/devops/viime/R/analyses.R
+++ b/devops/viime/R/analyses.R
@@ -171,7 +171,7 @@ roc_analysis <- function(measurements, groups, group1_name, group2_name, column_
         group_mask <- c(group_mask, 1)
     }
   }
-  
+
   # make sure row order is preserved
   if (group_mask[1] == 0) {
     # remove all rows not in group1 or group2

--- a/viime/views.py
+++ b/viime/views.py
@@ -831,6 +831,8 @@ def get_roc(validated_table: ValidatedMetaboliteTable,
     errors = {}
     try:
         columns = json.loads(columns)
+        if len(columns) == 0:
+            errors['columns'] = ['Invalid columns, must be non-empty']
     except ValueError:
         errors['columns'] = ['Invalid columns, must be a list']
     if not (groups == group1).sum().sum():


### PR DESCRIPTION
Catch opencpu errors caused by user input or failed analyses. This will prevent Sentry errors being reported when a high loading threshold causes a factor analysis to fail, for example.