### PR TITLE
Download PNG of ROC Plot

### DIFF
--- a/web/src/components/vis/GroupPredictionTile.vue
+++ b/web/src/components/vis/GroupPredictionTile.vue
@@ -147,6 +147,7 @@ export default {
     title="Group Prediction"
     :loading="plot.loading"
     expanded="expanded"
+    download
   >
     <template #controls>
       <v-toolbar

--- a/web/src/components/vis/RocCurve.vue
+++ b/web/src/components/vis/RocCurve.vue
@@ -116,7 +116,7 @@ export default {
   </div>
 </template>
 
-<style>
+<style scoped>
 .rocContainer {
   position: absolute;
   top: 0;


### PR DESCRIPTION
Adds functionality to download a png image of the displayed ROC curve (the same functionality implemented in the other visualizations)