### PR TITLE
Add error handling to ANOVA

### DIFF
--- a/devops/viime/R/analyses.R
+++ b/devops/viime/R/analyses.R
@@ -77,7 +77,21 @@ anova_tukey_adjustment <- function(measurements, groups, log_transformed=FALSE) 
   OUT <- NULL
   for (n in colnames(Metab)){
     mod <- lm(Metab[[n]] ~ Group)
-    a <- Anova(mod, type="III")
+
+    # catches any possible errors thrown by ANOVA and returns them
+    a <- tryCatch(
+        Anova(mod, type="III"),
+        error=function(err) {
+            return(err)
+        }
+      )
+
+    # check if 'a' is an error by checking if it inherits
+    # from the 'error' class
+    if (inherits(a, "error")) {
+      return(data.frame(error=a$message))
+    }
+
     x1 <- cbind(n,t(a[,"Pr(>F)"] ))
 
     emm.mod <- emmeans(mod, "Group")

--- a/viime/analyses.py
+++ b/viime/analyses.py
@@ -39,10 +39,15 @@ def anova_test(measurements: pd.DataFrame, groups: pd.Series,
 
     data = data.rename(columns={'(Intercept)': 'Intercept'})
 
+    formatted_data = clean(data).to_dict(orient='records')
+
+    if formatted_data[0].get('error') is not None:
+        return { 'error': formatted_data[0].get('error') }
+
     return {
         'groups': list(set(groups)),
         'pairs': [v for v in list(data)[4:] if not v.endswith('FoldChange')],
-        'data': clean(data).to_dict(orient='records')
+        'data': formatted_data
     }
 
 

--- a/viime/analyses.py
+++ b/viime/analyses.py
@@ -42,7 +42,7 @@ def anova_test(measurements: pd.DataFrame, groups: pd.Series,
     formatted_data = clean(data).to_dict(orient='records')
 
     if formatted_data[0].get('error') is not None:
-        return { 'error': formatted_data[0].get('error') }
+        return {'error': formatted_data[0].get('error')}
 
     return {
         'groups': list(set(groups)),

--- a/web/src/components/vis/AnovaTable.vue
+++ b/web/src/components/vis/AnovaTable.vue
@@ -22,6 +22,11 @@ export default {
       type: Array,
       required: true,
     },
+    errorMsg: { // error message to display if ANOVA fails, if applicable
+      type: String,
+      required: false,
+      default: '',
+    },
   },
 
   computed: {
@@ -52,6 +57,11 @@ export default {
 </script>
 
 <template lang="pug">
-metabolite-table(:headers="headers", :items="items", :threshold="threshold",
-    :value="value", @input="$emit('input', $event)")
+metabolite-table(
+    :headers="headers",
+    :items="items",
+    :threshold="threshold",
+    :value="value",
+    :no-data-available-msg="`ANOVA failed. ${errorMsg}`",
+    @input="$emit('input', $event)")
 </template>

--- a/web/src/components/vis/AnovaTable.vue
+++ b/web/src/components/vis/AnovaTable.vue
@@ -15,7 +15,6 @@ export default {
     },
     threshold: {
       type: Number,
-      required: false,
       default: 0.05,
     },
     value: { // string[]
@@ -24,7 +23,6 @@ export default {
     },
     errorMsg: { // error message to display if ANOVA fails, if applicable
       type: String,
-      required: false,
       default: '',
     },
   },

--- a/web/src/components/vis/AnovaTableTile.vue
+++ b/web/src/components/vis/AnovaTableTile.vue
@@ -62,12 +62,6 @@ export default {
         data,
       };
     },
-    anovaError() {
-      if (this?.plot?.data?.error) {
-        return this.plot.data.error;
-      }
-      return '';
-    },
   },
 
   methods: {
@@ -99,7 +93,7 @@ vis-tile-large(v-if="plot", title="Anova Table", :loading="plot.loading", expand
       v-if="plot.data",
       :data="tableData",
       :threshold="threshold",
-      :error-msg="anovaError",
+      :error-msg="plot.data.error || ''",
       v-model="selected")
 </template>
 

--- a/web/src/components/vis/AnovaTableTile.vue
+++ b/web/src/components/vis/AnovaTableTile.vue
@@ -62,6 +62,12 @@ export default {
         data,
       };
     },
+    anovaError() {
+      if (this?.plot?.data?.error) {
+        return this.plot.data.error;
+      }
+      return '';
+    },
   },
 
   methods: {
@@ -93,6 +99,7 @@ vis-tile-large(v-if="plot", title="Anova Table", :loading="plot.loading", expand
       v-if="plot.data",
       :data="tableData",
       :threshold="threshold",
+      :error-msg="anovaError",
       v-model="selected")
 </template>
 

--- a/web/src/components/vis/MetaboliteTable.vue
+++ b/web/src/components/vis/MetaboliteTable.vue
@@ -113,7 +113,7 @@ v-data-table.elevation-1.main(:headers="headers", :items="items", disable-initia
         :class="isInteresting(props.item[c.value]) ? 'highlight' : ''")
       | {{ format(props.item[c.value]) }}
   template(slot="no-data")
-    v-text {{ noDataAvailableMsg }}
+    | {{ noDataAvailableMsg }}
 </template>
 
 <style scoped>

--- a/web/src/components/vis/MetaboliteTable.vue
+++ b/web/src/components/vis/MetaboliteTable.vue
@@ -20,12 +20,10 @@ export default {
     },
     threshold: {
       type: Number,
-      required: false,
       default: 0.05,
     },
     noDataAvailableMsg: { // allows displaying a custom message when table has no data.
       type: String,
-      required: false,
       default: 'No data available',
     },
   },

--- a/web/src/components/vis/MetaboliteTable.vue
+++ b/web/src/components/vis/MetaboliteTable.vue
@@ -23,6 +23,11 @@ export default {
       required: false,
       default: 0.05,
     },
+    noDataAvailableMsg: { // allows displaying a custom message when table has no data.
+      type: String,
+      required: false,
+      default: 'No data available',
+    },
   },
 
   data() {
@@ -107,6 +112,8 @@ v-data-table.elevation-1.main(:headers="headers", :items="items", disable-initia
     td.cell.text-xs-right(v-for="c in headers.slice(1)",
         :class="isInteresting(props.item[c.value]) ? 'highlight' : ''")
       | {{ format(props.item[c.value]) }}
+  template(slot="no-data")
+    v-text {{ noDataAvailableMsg }}
 </template>
 
 <style scoped>


### PR DESCRIPTION
It's possible for the ANOVA test to fail on a dataset; currently this results in the R script crashing, which causes OpenCPU to return an error, which in turn triggers a sentry error in production. This PR will add error-handling to gracefully handle these errors on the server and display an appropriate error message in the web client. 

Resolves #599.