### PR TITLE
Enlarge font size in ROC curve and include AUC in png download

### DIFF
--- a/web/src/components/vis/GroupPredictionTile.vue
+++ b/web/src/components/vis/GroupPredictionTile.vue
@@ -228,7 +228,7 @@ export default {
         dense="dense"
         :card="false"
       >
-        <v-toolbar-title>Metabolites</v-toolbar-title>
+        <v-toolbar-title v-text="`Metabolites (${metabolites.length})`" />
       </v-toolbar>
       <v-card
         class="mx-3 px-1"

--- a/web/src/components/vis/RocCurve.vue
+++ b/web/src/components/vis/RocCurve.vue
@@ -22,7 +22,7 @@ export default {
   data() {
     return {
       margin: {
-        top: 40,
+        top: 30,
         right: 20,
         bottom: 50,
         left: 150,
@@ -34,7 +34,7 @@ export default {
       return 1000 - this.margin.left - this.margin.right;
     },
     height() {
-      return 800 - this.margin.top - this.margin.bottom;
+      return 850 - this.margin.top - this.margin.bottom;
     },
     xScale() {
       return scaleLinear()
@@ -73,10 +73,6 @@ export default {
 
 <template>
   <div class="rocContainer">
-    <span
-      style="margin: 10px; font-weight: bold;"
-      v-text="`AUC = ${auc.toPrecision(3)}`"
-    />
     <svg
       :width="width + margin.left + margin.right"
       :height="height + margin.top + margin.bottom"
@@ -102,15 +98,23 @@ export default {
         </g>
         <text
           text-anchor="end"
+          class="label"
           :y="height - 6"
           :x="width"
         >1 - Specificity</text>
         <text
           text-anchor="end"
+          class="label"
           y="6"
           dy=".75em"
           transform="rotate(-90)"
         >Sensitivity</text>
+      </g>
+      <g :transform="`translate(${width / 2},${height + margin.top + margin.bottom})`">
+        <text
+          style="font-size: 1.1em; font-weight: bold;"
+          v-text="`Area Under the Curve (AUC) = ${auc.toPrecision(3)}`"
+        />
       </g>
     </svg>
   </div>
@@ -125,17 +129,27 @@ export default {
   bottom: 0;
   display: flex;
 }
+
 .rocCurve {
   fill: none;
   stroke: steelblue;
-  stroke-width: 1.5px;
+  stroke-width: 3px;
 }
 
 .diagonal {
   fill: none;
   stroke: black;
-  stroke-width: 1.5px;
+  stroke-width: 3px;
   stroke-dasharray: 5,5;
+}
+
+g {
+  font-size: 1.2em;
+  stroke-width: 3px;
+}
+
+.label {
+  font-size: 1.5em;
 }
 
 </style>

--- a/web/src/components/vis/RocCurve.vue
+++ b/web/src/components/vis/RocCurve.vue
@@ -110,9 +110,9 @@ export default {
           transform="rotate(-90)"
         >Sensitivity</text>
       </g>
-      <g :transform="`translate(${width / 2},${height + margin.top + margin.bottom})`">
+      <g :transform="`translate(${width / 2},${margin.top - 10})`">
         <text
-          style="font-size: 1.1em; font-weight: bold;"
+          class="auc-label"
           v-text="`Area Under the Curve (AUC) = ${auc.toPrecision(3)}`"
         />
       </g>
@@ -128,6 +128,11 @@ export default {
   right: 0;
   bottom: 0;
   display: flex;
+}
+
+.auc-label {
+  font-size: 1.1em;
+  font-weight: bold;
 }
 
 .rocCurve {


### PR DESCRIPTION
This makes the fonts for the axes and AUC larger in the ROC curve component as discussed at today's meeting. I also put the AUC inside the svg plot so it's included in the downloaded PNG image.