### PR TITLE
Add specific error message to sample dataset panel if server is down

### DIFF
--- a/web/src/components/SampleBrowser.vue
+++ b/web/src/components/SampleBrowser.vue
@@ -7,6 +7,7 @@ export default {
     return {
       loading: true,
       samples: [],
+      error: false,
     };
   },
   computed: {
@@ -14,7 +15,15 @@ export default {
   },
   async created() {
     this.loading = true;
-    this.samples = (await SampleService.list()).data;
+
+    try {
+      const samples = await SampleService.list();
+      this.samples = samples.data;
+    } catch (err) {
+      this.samples = [];
+      this.error = true;
+    }
+
     this.loading = false;
   },
   methods: {
@@ -38,6 +47,8 @@ export default {
 .root
   .text-xs-center(v-if="loading")
     v-progress-circular(indeterminate, color="primary")
+  v-alert(:value="!loading && error", type="error")
+    | Could not reach the server
   v-alert(:value="!loading && samples.length === 0", type="info")
     | No Sample Data Sources available
   v-expansion-panel.sample-panels.elevation-0(v-if="!loading && samples.length > 0", :value="0")

--- a/web/src/components/SampleBrowser.vue
+++ b/web/src/components/SampleBrowser.vue
@@ -17,8 +17,8 @@ export default {
     this.loading = true;
 
     try {
-      const samples = await SampleService.list();
-      this.samples = samples.data;
+      const { data } = await SampleService.list();
+      this.samples = data;
     } catch (err) {
       this.samples = [];
       this.error = true;

--- a/web/src/components/SampleBrowser.vue
+++ b/web/src/components/SampleBrowser.vue
@@ -20,7 +20,6 @@ export default {
       const { data } = await SampleService.list();
       this.samples = data;
     } catch (err) {
-      this.samples = [];
       this.error = true;
     }
 


### PR DESCRIPTION
This PR prevents the "loading" icon from continuing to spin in the case where a server is not running (or otherwise not reachable) at the time the sample datasets panel appears. In that case, the endpoint for getting the sample datasets return a 500, but the code was not equipped to handle this error condition.

Addresses in part #622.