### PR TITLE
Remove mention of ldc from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,4 +111,4 @@ docker-compose up
 This command will spin up two Docker containers named `docker_backend_1` and
 `docker_opencpu_1`.
 
-Note, the web client will still need to be started using `yarn serve`. See the [ldc README](https://github.com/Kitware/ldc#usage) for more details.
+Note, the web client will still need to be started using `yarn serve`.

--- a/README.md
+++ b/README.md
@@ -101,16 +101,14 @@ flask db upgrade
 
 Getting started (`docker-compose`)
 ----------------------------------
-Install `ldc` from [here](https://github.com/Kitware/ldc) and start the project in Docker by running
+You can run the backend components for this project with Docker Compose:
 
 ```sh
-cd devops
-ldc up
+cd devops/docker
+docker-compose up
 ```
-This starts the backend in `production` mode. To switch to `development`, do
 
-```sh
-ldc dev backend
-```
+This command will spin up two Docker containers named `docker_backend_1` and
+`docker_opencpu_1`.
 
 Note, the web client will still need to be started using `yarn serve`. See the [ldc README](https://github.com/Kitware/ldc#usage) for more details.


### PR DESCRIPTION
Replaces advice of running `ldc` with direct invocation of `docker-compose`.