### PR TITLE
Display errors in ANOVA volcano plot

### DIFF
--- a/web/src/components/vis/AnovaVolcanoPlotTile.vue
+++ b/web/src/components/vis/AnovaVolcanoPlotTile.vue
@@ -146,7 +146,6 @@ vis-tile-large(v-if="dataset", title="Metabolite Anova Volanco Plot", :loading="
   v-alert(type="error",
       v-text="`ANOVA failed. ${plot.data && plot.data.error ? plot.data.error : ''}`",
       :value="plot.data && plot.data.error")
-
 </template>
 
 <style scoped>

--- a/web/src/components/vis/AnovaVolcanoPlotTile.vue
+++ b/web/src/components/vis/AnovaVolcanoPlotTile.vue
@@ -136,11 +136,17 @@ vis-tile-large(v-if="dataset", title="Metabolite Anova Volanco Plot", :loading="
     metabolite-colorer(:dataset="dataset", v-model="metaboliteColor",
         empty-option="No Color")
 
+  // can refactor v-if to use optional chaining when viime is updated to Vue 3
   volcano-plot.main(
-      v-if="plot.data",
+      v-if="plot.data && !plot.data.error",
       :rows="chartData",
       :min-fold-change="minFoldChange",
       :min-log-p="minLogP")
+  // same for value prop here
+  v-alert(type="error",
+      v-text="`ANOVA failed. ${plot.data && plot.data.error ? plot.data.error : ''}`",
+      :value="plot.data && plot.data.error")
+
 </template>
 
 <style scoped>

--- a/web/src/components/vis/AnovaVolcanoPlotTile.vue
+++ b/web/src/components/vis/AnovaVolcanoPlotTile.vue
@@ -143,7 +143,8 @@ vis-tile-large(v-if="dataset", title="Metabolite Anova Volanco Plot", :loading="
       :min-fold-change="minFoldChange",
       :min-log-p="minLogP")
   // same for value prop here
-  v-alert(type="error",
+  v-alert(
+      type="error",
       v-text="`ANOVA failed. ${plot.data && plot.data.error ? plot.data.error : ''}`",
       :value="plot.data && plot.data.error")
 </template>

--- a/web/src/components/vis/AnovaVolcanoPlotTile.vue
+++ b/web/src/components/vis/AnovaVolcanoPlotTile.vue
@@ -136,13 +136,13 @@ vis-tile-large(v-if="dataset", title="Metabolite Anova Volanco Plot", :loading="
     metabolite-colorer(:dataset="dataset", v-model="metaboliteColor",
         empty-option="No Color")
 
-  // can refactor v-if to use optional chaining when viime is updated to Vue 3
+  // TODO: can refactor v-if to use optional chaining when viime is updated to Vue 3
   volcano-plot.main(
       v-if="plot.data && !plot.data.error",
       :rows="chartData",
       :min-fold-change="minFoldChange",
       :min-log-p="minLogP")
-  // same for value prop here
+  // TODO: same for value prop here
   v-alert(
       type="error",
       v-text="`ANOVA failed. ${plot.data && plot.data.error ? plot.data.error : ''}`",


### PR DESCRIPTION
This PR displays an alert in the ANOVA Volcano Plot GUI instead of a blank plot if the ANOVA test fails on the server.

![anova](https://user-images.githubusercontent.com/37340715/90198851-f39ed500-dda0-11ea-8cff-818868e77588.png)
