### PR TITLE
Add error handling to Wilcoxon Test

### DIFF
--- a/devops/viime/R/analyses.R
+++ b/devops/viime/R/analyses.R
@@ -19,7 +19,19 @@ wilcoxon_test_z_scores <- function(measurements, groups, log_transformed=FALSE) 
     for(i in 1:ncol(Metab)) {
       a <- Metab[Group == groupA, i]
       b <- Metab[Group == groupB, i]
-      dat <- wilcox.test(as.numeric(a), as.numeric(b))
+      dat <- tryCatch(
+        wilcox.test(as.numeric(a), as.numeric(b)),
+        error=function(err) {
+            return(err)
+        }
+      )
+
+      # check if 'dat' is an error by checking if it inherits
+      # from the 'error' class
+      if (inherits(dat, "error")) {
+        return(data.frame(error=dat$message))
+      }
+
       result[i,1] <- as.numeric(gsub("$p.value [1]", "", dat[3]))
 
       # calculate fold change

--- a/viime/analyses.py
+++ b/viime/analyses.py
@@ -19,10 +19,15 @@ def wilcoxon_test(measurements: pd.DataFrame, groups: pd.Series,
         'log_transformed': log_transformed
     })
 
+    formatted_data = clean(data).to_dict(orient='records')
+
+    if formatted_data[0].get('error') is not None:
+        return {'error': formatted_data[0].get('error')}
+
     return {
         'groups': sorted(set(groups)),
         'pairs': [v for v in list(data)[1:] if not v.endswith('FoldChange')],
-        'data': clean(data).to_dict(orient='records')
+        'data': formatted_data
     }
 
 

--- a/web/src/components/vis/WilcoxonPlot.vue
+++ b/web/src/components/vis/WilcoxonPlot.vue
@@ -22,6 +22,10 @@ export default Vue.extend({
       type: Array,
       required: true,
     },
+    errorMsg: { // error message to display if ANOVA fails, if applicable
+      type: String,
+      default: '',
+    },
   },
 
   computed: {
@@ -47,6 +51,11 @@ export default Vue.extend({
 </script>
 
 <template lang="pug">
-metabolite-table(:headers="headers", :items="items", :threshold="threshold",
-    :value="value", @input="$emit('input', $event)")
+metabolite-table(
+    :headers="headers",
+    :items="items",
+    :no-data-available-msg="`Wilcoxon Test failed. ${errorMsg}`",
+    :threshold="threshold",
+    :value="value",
+    @input="$emit('input', $event)")
 </template>

--- a/web/src/components/vis/WilcoxonPlotTile.vue
+++ b/web/src/components/vis/WilcoxonPlotTile.vue
@@ -88,7 +88,12 @@ vis-tile-large(title="Wilcoxon Test", :loading="plot.loading", expanded)
     v-btn(flat, dark, block, @click="downloadTable")
       v-icon.mr-2 {{ $vuetify.icons.save }}
       | Download Table
-  wilcoxon-plot(v-if="plot.data", :data="tableData", :threshold="threshold", v-model="selected")
+  wilcoxon-plot(
+      v-if="plot.data",
+      :data="tableData",
+      :threshold="threshold",
+      :error-msg="plot.data.error || ''",
+      v-model="selected")
 </template>
 
 <style scoped>


### PR DESCRIPTION
This PR adds error handling similar to what was added to ANOVA (https://github.com/girder/viime/pull/605) to the Wilcoxon test. If an error occurs in the R code executing the Wilcoxon test, the opencpu server returns the error message to Flask, which in turn returns it to the client, which displays it to the user.