### PR TITLE
Disable zoom controls on all vis tiles

### DIFF
--- a/web/src/components/vis/VisTile.vue
+++ b/web/src/components/vis/VisTile.vue
@@ -75,13 +75,6 @@ v-flex.white.rounded.main(shrink=1, :class="scaleClass")
         slot(name="help")
     v-spacer
     v-toolbar-items
-      v-btn(@click="setScaleIndex(scaleIndex - 1)", :disabled="scaleIndex === 0", icon)
-        v-icon {{ $vuetify.icons.magnifyMinus }}
-      v-select.scaleFactor.pt-1(:value="scaleIndex", @change="setScaleIndex($event)",
-          :items="scaleOptions", hide-details, item-text="text", item-value="value")
-      v-btn(@click="setScaleIndex(scaleIndex + 1)",
-          :disabled="scaleIndex === scales.length - 1", icon)
-        v-icon {{ $vuetify.icons.magnifyPlus }}
       v-btn(v-if="svgDownload", @click="downloadSVG", icon)
         v-icon {{ $vuetify.icons.save }}
       slot(name="controls")

--- a/web/src/components/vis/VisTile.vue
+++ b/web/src/components/vis/VisTile.vue
@@ -63,6 +63,8 @@ v-flex.white.rounded.main(shrink=1)
   position: relative;
   display: flex;
   flex-direction: column;
+  grid-column: span 2;
+  grid-row: span 2;
 }
 .rounded {
   border-radius: 5px;

--- a/web/src/components/vis/VisTile.vue
+++ b/web/src/components/vis/VisTile.vue
@@ -1,5 +1,4 @@
 <script>
-import { format } from 'd3-format';
 import { downloadSVG } from '../../utils/exporter';
 import HelpDialog from '../toolbar/HelpDialog.vue';
 

--- a/web/src/components/vis/VisTile.vue
+++ b/web/src/components/vis/VisTile.vue
@@ -24,35 +24,11 @@ export default {
 
   data() {
     return {
-      scales: [
-        { scaleFactor: 0.5, cssClass: 'span1' },
-        { scaleFactor: 1, cssClass: 'span2' },
-        { scaleFactor: 1.5, cssClass: 'span3' },
-        { scaleFactor: 2, cssClass: 'span4' },
-        { scaleFactor: 2.5, cssClass: 'span5' },
-      ],
-      scaleIndex: 1,
       showHelp: false,
     };
   },
 
-  computed: {
-    scaleClass() {
-      return this.scales[this.scaleIndex].cssClass;
-    },
-    scaleFactor() {
-      return this.scales[this.scaleIndex].scaleFactor;
-    },
-    scaleOptions() {
-      const f = format('.0%');
-      return this.scales.map((d, i) => ({ text: f(d.scaleFactor), value: i }));
-    },
-  },
-
   methods: {
-    setScaleIndex(value) {
-      this.scaleIndex = Math.max(Math.min(Number.parseInt(value, 10), this.scales.length - 1), 0);
-    },
     hasHelp() {
       return this.$slots.help != null || this.$scopedSlots.help != null;
     },
@@ -67,7 +43,7 @@ export default {
 </script>
 
 <template lang="pug">
-v-flex.white.rounded.main(shrink=1, :class="scaleClass")
+v-flex.white.rounded.main(shrink=1)
   v-toolbar.primary.darken-3.top-rounded(dark, flat, dense)
     v-toolbar-title {{ title }}
     v-toolbar-items(v-if="hasHelp()")
@@ -84,43 +60,6 @@ v-flex.white.rounded.main(shrink=1, :class="scaleClass")
 </template>
 
 <style scoped lang="scss">
-.span1 {
-  grid-column: span 1;
-  grid-row: span 1;
-}
-.span2 {
-  grid-column: span 2;
-  grid-row: span 2;
-}
-.span3 {
-  grid-column: span 3;
-  grid-row: span 3;
-}
-.span4 {
-  grid-column: span 4;
-  grid-row: span 4;
-}
-.span5 {
-  grid-column: span 5;
-  grid-row: span 5;
-}
-.span6 {
-  grid-column: span 6;
-  grid-row: span 6;
-}
-.span7 {
-  grid-column: span 7;
-  grid-row: span 7;
-}
-.span8 {
-  grid-column: span 8;
-  grid-row: span 8;
-}
-
-.scaleFactor {
-  max-width: 4em;
-}
-
 .main {
   position: relative;
   display: flex;


### PR DESCRIPTION
This removes the zoom controls from all vis tiles, to address the fact that most of our plots did not attach any semantics to these controls, leading to bad UX.

Fixes #616 