### PR TITLE
Add a popover help panel to VisTileLarge, and enable it in all analysis pages

### DIFF
--- a/web/src/components/vis/AnovaTableTile.vue
+++ b/web/src/components/vis/AnovaTableTile.vue
@@ -73,7 +73,12 @@ export default {
 </script>
 
 <template lang="pug">
-vis-tile-large(v-if="plot", title="Anova Table", :loading="plot.loading", expanded)
+vis-tile-large(
+    v-if="plot",
+    title="Anova Table",
+    analysis-path="anova",
+    :loading="plot.loading",
+    expanded)
   template(#controls)
     metabolite-filter(:dataset="dataset", v-model="metaboliteFilter", hide-selection)
     metabolite-colorer(:dataset="dataset", v-model="metaboliteColor", hide-selection,

--- a/web/src/components/vis/AnovaVolcanoPlotTile.vue
+++ b/web/src/components/vis/AnovaVolcanoPlotTile.vue
@@ -110,8 +110,13 @@ export default {
 </script>
 
 <template lang="pug">
-vis-tile-large(v-if="dataset", title="Metabolite Anova Volanco Plot", :loading="false",
-    download, expanded)
+vis-tile-large(
+    v-if="dataset",
+    title="Metabolite Anova Volanco Plot",
+    analysis-path="anova_volcano",
+    :loading="false",
+    download,
+    expanded)
   template(#controls)
     toolbar-option(v-if="hasMoreThanTwoGroups",
         :value="combination || defaultCombination", @change="combination = $event",

--- a/web/src/components/vis/BoxPlotLargeTile.vue
+++ b/web/src/components/vis/BoxPlotLargeTile.vue
@@ -69,8 +69,13 @@ export default {
 </script>
 
 <template lang="pug">
-vis-tile-large(v-if="dataset", title="Metabolite Box Plot", :loading="false",
-    download, expanded)
+vis-tile-large(
+    v-if="dataset",
+    title="Metabolite Box Plot",
+    analysis-path="boxplot",
+    :loading="false",
+    download,
+    expanded)
   template(#controls)
     metabolite-filter(:dataset="dataset", v-model="metaboliteFilter")
     sample-filter(:dataset="dataset", v-model="sampleFilter",

--- a/web/src/components/vis/CorrelationTile.vue
+++ b/web/src/components/vis/CorrelationTile.vue
@@ -145,8 +145,13 @@ export default {
 </script>
 
 <template lang="pug">
-vis-tile-large.correlation(v-if="plot", title="Correlation Network", :loading="plot.loading",
-    expanded, download)
+vis-tile-large.correlation(
+    v-if="plot",
+    title="Correlation Network",
+    analysis-path="correlation",
+    :loading="plot.loading",
+    expanded,
+    download)
   template(#controls)
     toolbar-option(title="Method", :value="plot.args.method",
         :options="correlation_methods",

--- a/web/src/components/vis/GroupPredictionTile.vue
+++ b/web/src/components/vis/GroupPredictionTile.vue
@@ -145,7 +145,7 @@ export default {
   <vis-tile-large
     v-if="plot"
     title="Group Prediction"
-    analysisPath="roc"
+    analysis-path="roc"
     :loading="plot.loading"
     expanded="expanded"
     download

--- a/web/src/components/vis/GroupPredictionTile.vue
+++ b/web/src/components/vis/GroupPredictionTile.vue
@@ -145,6 +145,7 @@ export default {
   <vis-tile-large
     v-if="plot"
     title="Group Prediction"
+    analysisPath="roc"
     :loading="plot.loading"
     expanded="expanded"
     download

--- a/web/src/components/vis/HeatmapTile.vue
+++ b/web/src/components/vis/HeatmapTile.vue
@@ -117,7 +117,13 @@ export default {
 </script>
 
 <template lang="pug">
-vis-tile-large(v-if="plot", title="Heatmap", expanded, download, :download-impl="download",
+vis-tile-large(
+    v-if="plot",
+    title="Heatmap",
+    analysis-path="heatmap",
+    expanded,
+    download,
+    :download-impl="download",
     :loading="plot.loading || !dataset.ready || !values || values.length === 0")
   template(#controls)
     metabolite-filter(:dataset="dataset", v-model="metaboliteFilter")

--- a/web/src/components/vis/PcaPage/PcaPage.vue
+++ b/web/src/components/vis/PcaPage/PcaPage.vue
@@ -79,7 +79,7 @@ export default {
 </script>
 
 <template lang="pug">
-vis-tile-large(title="Principal Component Analysis", :loading="false")
+vis-tile-large(title="Principal Component Analysis", analysis-path="pcapage", :loading="false")
   template(#controls)
     v-toolbar.darken-3(color="primary", dark, flat, dense, :card="false")
       v-toolbar-title PC selector

--- a/web/src/components/vis/VisTileLarge.vue
+++ b/web/src/components/vis/VisTileLarge.vue
@@ -1,11 +1,21 @@
 <script>
 import { downloadSVG } from '../../utils/exporter';
+import { analysisTable } from '@/components/vis/analyses';
+import RenderJsx from '@/utils/RenderJsx';
 
 export default {
+  components: {
+    RenderJsx,
+  },
+
   props: {
     title: {
       type: String,
       required: true,
+    },
+    analysisPath: {
+      type: String,
+      default: '',
     },
     loading: {
       type: Boolean,
@@ -24,6 +34,12 @@ export default {
   computed: {
     hasControls() {
       return !!this.$slots.controls || !!this.$scopedSlots.controls;
+    },
+
+    helpText() {
+      if (this.analysisPath) {
+        return analysisTable[this.analysisPath].description;
+      }
     },
   },
 
@@ -54,6 +70,14 @@ v-layout(v-else, row, fill-height)
       v-btn(flat, dark, block, @click="downloadImage")
         v-icon.mr-2 {{ $vuetify.icons.save }}
         | Download PNG
+
+    v-menu(v-if="helpText", offset-y)
+      template(v-slot:activator="{ on }")
+        v-btn(flat, dark, block, v-on="on")
+          v-icon.mr-2 {{ $vuetify.icons.help }}
+          | What is this?
+      v-card
+        render-jsx(:f="helpText")
 
   v-layout(v-if="loading", justify-center, align-center)
     v-progress-circular(indeterminate, size="100", width="5")

--- a/web/src/components/vis/VisTileLarge.vue
+++ b/web/src/components/vis/VisTileLarge.vue
@@ -1,7 +1,7 @@
 <script>
-import { downloadSVG } from '../../utils/exporter';
 import { analysisTable } from '@/components/vis/analyses';
 import RenderJsx from '@/utils/RenderJsx';
+import { downloadSVG } from '../../utils/exporter';
 
 export default {
   components: {
@@ -40,6 +40,7 @@ export default {
       if (this.analysisPath) {
         return analysisTable[this.analysisPath].description;
       }
+      return null;
     },
   },
 

--- a/web/src/components/vis/VisTileLarge.vue
+++ b/web/src/components/vis/VisTileLarge.vue
@@ -76,7 +76,7 @@ v-layout(v-else, row, fill-height)
         v-btn(flat, dark, block, v-on="on")
           v-icon.mr-2 {{ $vuetify.icons.help }}
           | What is this?
-      v-card
+      v-card(max-width=300)
         render-jsx(:f="helpText")
 
   v-layout(v-if="loading", justify-center, align-center)

--- a/web/src/components/vis/VisTileLarge.vue
+++ b/web/src/components/vis/VisTileLarge.vue
@@ -1,5 +1,5 @@
 <script>
-import { analysisTable } from '@/components/vis/analyses';
+import { analysisMap } from '@/components/vis/analyses';
 import RenderJsx from '@/utils/RenderJsx';
 import { downloadSVG } from '../../utils/exporter';
 
@@ -38,7 +38,7 @@ export default {
 
     helpText() {
       if (this.analysisPath) {
-        return analysisTable[this.analysisPath].description;
+        return analysisMap[this.analysisPath].description;
       }
       return null;
     },

--- a/web/src/components/vis/WilcoxonPlotTile.vue
+++ b/web/src/components/vis/WilcoxonPlotTile.vue
@@ -72,7 +72,7 @@ export default {
 </script>
 
 <template lang="pug">
-vis-tile-large(title="Wilcoxon Test", :loading="plot.loading", expanded)
+vis-tile-large(title="Wilcoxon Test", analysis-path="wilcoxon", :loading="plot.loading", expanded)
   template(#controls)
     metabolite-filter(:dataset="dataset", v-model="metaboliteFilter", hide-selection)
     metabolite-colorer(:dataset="dataset", v-model="metaboliteColor", hide-selection,

--- a/web/src/components/vis/WilcoxonVolcanoPlotTile.vue
+++ b/web/src/components/vis/WilcoxonVolcanoPlotTile.vue
@@ -116,8 +116,13 @@ export default {
 </script>
 
 <template lang="pug">
-vis-tile-large(v-if="dataset", title="Metabolite Wilcoxon Volanco Plot", :loading="false",
-    download, expanded)
+vis-tile-large(
+    v-if="dataset",
+    title="Metabolite Wilcoxon Volanco Plot",
+    analysis-path="wilcoxon_volcano",
+    :loading="false",
+    download,
+    expanded)
   template(#controls)
     toolbar-option(:value="score", @change="score = $event", title="p-Value", :options="scores")
     toolbar-option(v-if="hasMoreThanTwoGroups",

--- a/web/src/components/vis/analyses.js
+++ b/web/src/components/vis/analyses.js
@@ -11,7 +11,7 @@ import { plot_types } from '../../utils/constants';
 import { correlation_methods } from './constants';
 import vuetify from '../../utils/vuetifyConfig';
 
-export default [
+const analysisList = [
   {
     path: 'pcapage',
     name: 'Principal Component Analysis',
@@ -164,3 +164,17 @@ export default [
     icon: vuetify.icons.pca,
   },
 ];
+
+const analysisTable = (() => {
+  let table = {};
+  analysisList.forEach((entry) => {
+    table[entry.path] = entry;
+  });
+
+  return table;
+})();
+
+export default analysisList;
+export {
+  analysisTable,
+};

--- a/web/src/components/vis/analyses.js
+++ b/web/src/components/vis/analyses.js
@@ -166,7 +166,7 @@ const analysisList = [
 ];
 
 const analysisTable = (() => {
-  let table = {};
+  const table = {};
   analysisList.forEach((entry) => {
     table[entry.path] = entry;
   });

--- a/web/src/components/vis/analyses.js
+++ b/web/src/components/vis/analyses.js
@@ -165,16 +165,13 @@ const analysisList = [
   },
 ];
 
-const analysisTable = (() => {
-  const table = {};
-  analysisList.forEach((entry) => {
-    table[entry.path] = entry;
-  });
-
-  return table;
-})();
+// Create a path-indexable map version of the analysis list.
+const analysisMap = Object.freeze(analysisList.reduce((map, entry) => ({
+  ...map,
+  [entry.path]: entry,
+}), {}));
 
 export default analysisList;
 export {
-  analysisTable,
+  analysisMap,
 };


### PR DESCRIPTION
This PR adds a help button to each analysis page which activates a popover that shows the same analysis description that is shown in the master analysis display.

This partially addresses #638 (to completely fix that issue, we need to clarify the help text for the correlation network as well).