### PR TITLE
Strip out columns with zero variance in factor analysis

### DIFF
--- a/devops/viime/R/analyses.R
+++ b/devops/viime/R/analyses.R
@@ -252,6 +252,7 @@ factor_analysis <- function(measurements, threshold) {
   #- (Eigenvalues higher than 1) -#
 
   # Principal Component Analysis to get eigenvalues
+  m.df <- m.df[ , which(apply(m.df, 2, var) != 0)]
   pca_a <- prcomp(m.df, center=T, scale=T)
 
   #getting the eigenvalues


### PR DESCRIPTION
The issue in #628 was caused by several columns that are all zero.  The principal component analysis is set up to rescale all columns to zero variance, which it clearly can't do in this case.  This removes all of those columns before executing the rest of the code.  I'm not sure if this is the correct thing to do, but it does fix the issue.  It might be worth asking Lillian.

Fixes #628