### PR TITLE
Use imperative reduction function

### DIFF
--- a/web/src/components/vis/analyses.js
+++ b/web/src/components/vis/analyses.js
@@ -181,10 +181,10 @@ const analysisList = [
 ];
 
 // Create a path-indexable map version of the analysis list.
-const analysisMap = Object.freeze(analysisList.reduce((map, entry) => ({
-  ...map,
-  [entry.path]: entry,
-}), {}));
+const analysisMap = Object.freeze(analysisList.reduce((map, entry) => {
+  map[entry.path] = entry;
+  return map;
+}, {}));
 
 export default analysisList;
 export {


### PR DESCRIPTION
This is to forestall possible performance problems. See [this comment](https://github.com/girder/viime/pull/644#discussion_r475755390) for details.