### PR TITLE
Improve table structure inferred during ingest

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -77,6 +77,12 @@ def pathological_table(client):
             'table': f.read(),
             'name': 'pathological.csv'
         })
+
+        # undo the guessed structure to exercise validation code
+        for row in csv_file.rows[1:]:
+            row['row_type'] = 'sample'
+        for column in csv_file.columns[2:]:
+            row['row_type'] = 'metabolite'
     db.session.add(csv_file)
     db.session.commit()
     yield csv_file

--- a/tests/test_row_column.py
+++ b/tests/test_row_column.py
@@ -43,7 +43,7 @@ def test_list_columns(client, table):
     }, {
         'column_header': 'meta',
         'column_index': 2,
-        'column_type': 'measurement',
+        'column_type': 'masked',
         'subtype': None,
         'meta': {}
     }, {

--- a/tests/test_table_validation.py
+++ b/tests/test_table_validation.py
@@ -173,11 +173,11 @@ def test_multiple_invalid_errors(pathological_table):
 
 def test_non_numeric_warning(client):
     table = """
-id,group,col1,col2
-w,a,-1,2
-x,a,0,0
-y,a,x,1
-z,b,5,2
+id,group,col1,col2,col3
+w,a,-1,2,3
+x,a,0,0,1
+y,a,x,1,4
+z,b,5,2,5
 """
 
     csv_file = csv_file_schema.load({'table': table, 'name': 'table.csv'})
@@ -195,11 +195,11 @@ z,b,5,2
 
 def test_missing_percent_warning(client):
     table = """
-id,group,col1,col2
-w,a,-1,2
-x,a,0,0
-y,a,,1
-z,b,,
+id,group,col1,col2,col3
+w,a,-1,2,1
+x,a,0,0,5
+y,a,,1,7
+z,b,,1,5
 """
 
     csv_file = csv_file_schema.load({'table': table, 'name': 'table.csv'})
@@ -220,7 +220,7 @@ def test_low_variance_warning(client):
     table = """
 id,group,col1,col2
 w,a,0,2
-x,a,0,0
+x,a,1e-8,0
 y,a,0,1
 z,b,0,10
 """


### PR DESCRIPTION
This is primarily intended to mask rows/columns by default that would result in table validation errors.  I could imagine much more sophisticated algorithms that would do a better job of finding the correct group column, but it is questionable if it is worth the time.