### PR TITLE
Stabilize test navbar usage

### DIFF
--- a/e2e-test/src/tests/anova.test.js
+++ b/e2e-test/src/tests/anova.test.js
@@ -1,5 +1,5 @@
 import { vBtn, vListTile } from 'jest-puppeteer-vuetify';
-import { uploadDataset } from '../util';
+import { uploadDataset, analyzeTable } from '../util';
 
 
 describe('the ANOVA page', () => {
@@ -10,11 +10,8 @@ describe('the ANOVA page', () => {
     await uploadDataset('anovaTest');
     await expect(page).toClickXPath(vListTile({ title: 'anovaTest.csv ', content: 'Dataset ready for analysis.' }) + vBtn('View Data'));
 
-    // click analyze table
-    await expect(page).toClickXPath(vListTile({ title: 'Analyze Table' }));
-
-    // click ANOVA
-    await expect(page).toClickXPath(vListTile({ title: 'ANOVA' }));
+    // open ANOVA analysis
+    await analyzeTable('ANOVA');
 
     // select some metabolites from ANOVA by adding the highlighted Metabolites to the selected set
     /* eslint prefer-template: "off" */

--- a/e2e-test/src/tests/cleanUp.test.js
+++ b/e2e-test/src/tests/cleanUp.test.js
@@ -12,13 +12,20 @@ describe('relabel dataset', () => {
 
     await uploadDataset('cleanUpTest');
 
-    await expect(page).toClickXPath(vListTile({ title: 'cleanUpTest.csv ', content: 'Dataset processed with 1 validation failures' }) + vBtn('View Data'));
+    await expect(page).toClickXPath(vListTile({ title: 'cleanUpTest.csv ', content: 'Dataset ready for analysis' }) + vBtn('View Data'));
+
+    //  verify the dataset is ready to process
+    await page.waitForXPath(vListTile({ title: 'cleanUpTest.csv' }) + vIcon({ cssClass: 'mdi mdi-check theme--light success--text' }));
+
+    // select the third column(column 'C', currently masked) and mark it as a 'Metabolite'
+    await expect(page).toClickXPath("//div[contains(@class,'column-header-cell type-masked mdi mdi-eye-off')]");
+    await expect(page).toClickXPath("//input[@value='measurement']");
 
     //  verify the dataset is failing
     await page.waitForXPath(vListTile({ title: 'cleanUpTest.csv' }) + vIcon({ cssClass: 'mdi mdi-alert theme--light warning--text' }));
 
     // select the third column(column 'C') and mark it as a 'Group'
-    await expect(page).toClickXPath("//div[@class='column-header-cell type-measurement'][contains(text(), 'C')]");
+    await expect(page).toClickXPath("//div[contains(@class,'column-header-cell type-measurement')][contains(text(), 'C')]");
     await expect(page).toClickXPath("//input[@value='group']");
 
     //  verify the dataset is ready to process
@@ -30,7 +37,14 @@ describe('relabel dataset', () => {
 
     await uploadDataset('cleanUpTest1');
 
-    await expect(page).toClickXPath(vListTile({ title: 'cleanUpTest1.csv ', content: 'Dataset processed with 1 validation failures' }) + vBtn('View Data'));
+    await expect(page).toClickXPath(vListTile({ title: 'cleanUpTest1.csv ', content: 'Dataset ready for analysis' }) + vBtn('View Data'));
+
+    //  verify the dataset is ready to process
+    await page.waitForXPath(vListTile({ title: 'cleanUpTest1.csv' }) + vIcon({ cssClass: 'mdi mdi-check theme--light success--text' }));
+
+    // select the third column(column 'C', currently masked) and mark it as a 'Metabolite'
+    await expect(page).toClickXPath("//div[contains(@class,'column-header-cell type-masked mdi mdi-eye-off')]");
+    await expect(page).toClickXPath("//input[@value='measurement']");
 
     //  verify the dataset is failing
     await page.waitForXPath(vListTile({ title: 'cleanUpTest1.csv' }) + vIcon({ cssClass: 'mdi mdi-alert theme--light warning--text' }));
@@ -45,7 +59,7 @@ describe('relabel dataset', () => {
     await page.waitForXPath(vListTile({ title: 'cleanUpTest1.csv' }) + vIcon({ cssClass: 'mdi mdi-check theme--light success--text' }));
 
     // verify the column is masked and then click on the masked column
-    await expect(page).toClickXPath("//div[@class='column-header-cell type-masked mdi mdi-eye-off']");
+    await expect(page).toClickXPath("//div[contains(@class,'column-header-cell type-masked mdi mdi-eye-off')]");
 
     // select the masked column and mark it as a 'Group'
     await expect(page).toClickXPath("//input[@value='group']");
@@ -59,28 +73,21 @@ describe('relabel dataset', () => {
 
     await uploadDataset('cleanUpTest2');
 
-    await expect(page).toClickXPath(vListTile({ title: 'cleanUpTest2.csv ', content: 'Dataset processed with 1 validation failures' }) + vBtn('View Data'));
-
-    //  verify the dataset is failing
-    await page.waitForXPath(vListTile({ title: 'cleanUpTest2.csv' }) + vIcon({ cssClass: 'mdi mdi-alert theme--light warning--text' }));
-
-    // select the third column(column 'C') and mark it as a 'Group'
-    await expect(page).toClickXPath("//div[@class='column-header-cell type-measurement'][contains(text(), 'C')]");
-    await expect(page).toClickXPath("//input[@value='group']");
+    await expect(page).toClickXPath(vListTile({ title: 'cleanUpTest2.csv ', content: 'Dataset ready for analysis' }) + vBtn('View Data'));
 
     //  verify the dataset is ready to process
     await page.waitForXPath(vListTile({ title: 'cleanUpTest2.csv' }) + vIcon({ cssClass: 'mdi mdi-check theme--light success--text' }));
 
-    // select file name column and click 'Metabolite' button while it should have been metadata
+    // select file name column and change it from Group to Metadata
     await expect(page).toClickXPath("//div[@class='cell type-header']//div[contains(text(), 'File Name')]");
-    await expect(page).toClickXPath("//input[@value='measurement']");
+    await expect(page).toClickXPath("//input[@value='metadata']");
 
-    // verify the dataset gets an error
+    // verify the dataset gets an error because there is no Group column
     await page.waitForXPath(vListTile({ title: 'cleanUpTest2.csv' }) + vIcon({ cssClass: 'mdi mdi-alert theme--light warning--text' }));
 
-    // Fixing the select file name column again and click 'Metadata' button
-    await expect(page).toClickXPath("//div[@class='cell type-header']//div[contains(text(), 'File Name')]");
-    await expect(page).toClickXPath("//span[contains(text(), 'Metadata')]");
+    // Fixing the select treatment column and click 'Group' button
+    await expect(page).toClickXPath("//div[@class='cell type-header']//div[contains(text(), 'Treatment')]");
+    await expect(page).toClickXPath("//span[contains(text(), 'Group')]");
 
     //  verify the dataset is ready to process again
     await page.waitForXPath(vListTile({ title: 'cleanUpTest2.csv' }) + vIcon({ cssClass: 'mdi mdi-check theme--light success--text' }));

--- a/e2e-test/src/tests/delete.test.js
+++ b/e2e-test/src/tests/delete.test.js
@@ -37,10 +37,10 @@ describe('delete dataset', () => {
     await page.waitForXPath(vListTile({ title: 'deleteTest1.csv ', content: 'Dataset ready for analysis' }));
 
     await uploadDataset('deleteTest2');
-    await page.waitForXPath(vListTile({ title: 'deleteTest2.csv ', content: 'Dataset processed with 1 validation failures' }));
+    await page.waitForXPath(vListTile({ title: 'deleteTest2.csv ', content: 'Dataset ready for analysis' }));
 
     await uploadDataset('deleteTest3');
-    await page.waitForXPath(vListTile({ title: 'deleteTest3.csv ', content: 'Dataset processed with 1 validation failures' }));
+    await page.waitForXPath(vListTile({ title: 'deleteTest3.csv ', content: 'Dataset ready for analysis' }));
 
     // wait for data sets to be all uploaded before deletion
     await new Promise((resolve) => setTimeout(resolve, 1000));

--- a/e2e-test/src/tests/download.test.js
+++ b/e2e-test/src/tests/download.test.js
@@ -1,5 +1,5 @@
 import { vBtn, vListTile } from 'jest-puppeteer-vuetify';
-import { uploadDataset } from '../util';
+import { uploadDataset, analyzeTable } from '../util';
 
 
 describe('download dataset', () => {
@@ -50,11 +50,8 @@ describe('download dataset', () => {
     await uploadDataset('downloadTest');
     await expect(page).toClickXPath(vListTile({ title: 'downloadTest.csv ', content: 'Dataset ready for analysis.' }) + vBtn('View Data'));
 
-    // click analyze table
-    await expect(page).toClickXPath(vListTile({ title: 'Analyze Table' }));
-
-    // click ANOVA
-    await expect(page).toClickXPath(vListTile({ title: 'ANOVA' }));
+    // open ANOVA analysis
+    await analyzeTable('ANOVA');
 
     // select 7 rows: Alanine, Glutamine, Nicotinurate, Sarcosine, Aspartate, Glucose, Glutathione
     /* eslint prefer-template: "off" */

--- a/e2e-test/src/tests/upload.test.js
+++ b/e2e-test/src/tests/upload.test.js
@@ -8,7 +8,7 @@ describe('upload dataset', () => {
     const fileInputElementHandle = await page.waitForXPath("//input[@type='file']");
     await fileInputElementHandle.uploadFile('../e2e-test/data/uploadTest.csv');
     await page.waitForXPath(vListTile({ title: 'uploadTest.csv ' }));
-    await page.waitForXPath(vListTile({ title: 'uploadTest.csv ', content: 'Dataset processed with 1 validation failures' }));
+    await page.waitForXPath(vListTile({ title: 'uploadTest.csv ', content: 'Dataset ready for analysis' }));
   });
   it('upload 3 dataset', async () => {
     await expect(page).toClickXPath(vBtn('Your Datasets'));
@@ -17,14 +17,14 @@ describe('upload dataset', () => {
 
     await fileInputElementHandle.uploadFile('../e2e-test/data/uploadTest1.csv');
     await page.waitForXPath(vListTile({ title: 'uploadTest1.csv ' }));
-    await page.waitForXPath(vListTile({ title: 'uploadTest1.csv ', content: 'Dataset processed with 1 validation failures' }));
+    await page.waitForXPath(vListTile({ title: 'uploadTest1.csv ', content: 'Dataset ready for analysis' }));
 
     await fileInputElementHandle.uploadFile('../e2e-test/data/uploadTest2.csv');
     await page.waitForXPath(vListTile({ title: 'uploadTest2.csv ' }));
-    await page.waitForXPath(vListTile({ title: 'uploadTest2.csv ', content: 'Dataset processed with 1 validation failures' }));
+    await page.waitForXPath(vListTile({ title: 'uploadTest2.csv ', content: 'Dataset ready for analysis' }));
 
     await fileInputElementHandle.uploadFile('../e2e-test/data/uploadTest3.csv');
     await page.waitForXPath(vListTile({ title: 'uploadTest3.csv ' }));
-    await page.waitForXPath(vListTile({ title: 'uploadTest3.csv ', content: 'Dataset processed with 1 validation failures' }));
+    await page.waitForXPath(vListTile({ title: 'uploadTest3.csv ', content: 'Dataset ready for analysis' }));
   });
 });

--- a/e2e-test/src/util.js
+++ b/e2e-test/src/util.js
@@ -20,3 +20,18 @@ export async function uploadDataset(datasetName) {
   await fileInputElementHandle.uploadFile(filePath);
   await page.waitForXPath(vListTile({ title: fileName }));
 }
+
+/**
+ * Opens the Analysis nav tab and clicks on the given analysis
+ * @param {string} analysis
+ */
+export async function analyzeTable(analysis) {
+  if (await page.$x(`//div[contains(@class, "v-list__group__header--active")]/div${vListTile({ title: 'Analyze Table' })}`).length === 0) {
+    // only click on the Analyze Table nav item if it isn't open already
+    await expect(page).toClickXPath(vListTile({ title: 'Analyze Table' }));
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+  }
+  // click the desired analysis
+  await expect(page).toClickXPath(vListTile({ title: analysis }));
+  await new Promise((resolve) => setTimeout(resolve, 1000));
+}

--- a/e2e-test/src/util.js
+++ b/e2e-test/src/util.js
@@ -26,7 +26,7 @@ export async function uploadDataset(datasetName) {
  * @param {string} analysis
  */
 export async function analyzeTable(analysis) {
-  if (await page.$x(`//div[contains(@class, "v-list__group__header--active")]/div${vListTile({ title: 'Analyze Table' })}`).length === 0) {
+  if ((await page.$x(`//div[contains(@class, "v-list__group__header--active")]/div${vListTile({ title: 'Analyze Table' })}`)).length === 0) {
     // only click on the Analyze Table nav item if it isn't open already
     await expect(page).toClickXPath(vListTile({ title: 'Analyze Table' }));
     await new Promise((resolve) => setTimeout(resolve, 1000));


### PR DESCRIPTION
Using the Analysis methods in the nav bar involves clicking the
`Analysis` nav bar option, which triggers an animation which reveals the
analyses. Tests were trying to click the analysis before it was
guaranteed to be revealed, which was causing flake.

Move opening an analysis page into a utility function.