### PR TITLE
Use toRef instead of computed values

### DIFF
--- a/web/src/components/vis/PcaPage/LoadingsPlot.vue
+++ b/web/src/components/vis/PcaPage/LoadingsPlot.vue
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { defineComponent, computed } from '@vue/composition-api';
+import { defineComponent, computed, toRef } from '@vue/composition-api';
 import LoadingsPlot from '@/components/vis/LoadingsPlot.vue';
 import VisTile from '@/components/vis/VisTile.vue';
 import usePlotData from '../use/usePlotData';
@@ -25,9 +25,7 @@ export default defineComponent({
   },
   components: { LoadingsPlot, VisTile },
   setup(props) {
-    // TODO this won't be necessary in Vue 3
-    const id = computed(() => props.id);
-    const { plot } = usePlotData(id, 'loadings');
+    const { plot } = usePlotData(toRef(props, 'id'), 'loadings');
     return { plot };
   },
 });

--- a/web/src/components/vis/PcaPage/ScorePlot.vue
+++ b/web/src/components/vis/PcaPage/ScorePlot.vue
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { defineComponent, computed } from '@vue/composition-api';
+import { defineComponent, computed, toRef } from '@vue/composition-api';
 import ScorePlot from '@/components/vis/ScorePlot.vue';
 import VisTile from '@/components/vis/VisTile.vue';
 import usePlotData from '../use/usePlotData';
@@ -25,9 +25,7 @@ export default defineComponent({
   },
   components: { ScorePlot, VisTile },
   setup(props) {
-    // TODO this won't be necessary in Vue 3
-    const id = computed(() => props.id);
-    const { plot, dataset } = usePlotData(id, 'pca');
+    const { plot, dataset } = usePlotData(toRef(props, 'id'), 'pca');
     return {
       plot,
       dataset,

--- a/web/src/components/vis/PcaPage/ScreePlot.vue
+++ b/web/src/components/vis/PcaPage/ScreePlot.vue
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { defineComponent, computed } from '@vue/composition-api';
+import { defineComponent, computed, toRef } from '@vue/composition-api';
 import ScreePlot from '@/components/vis/ScreePlot.vue';
 import VisTile from '@/components/vis/VisTile.vue';
 import usePlotData from '../use/usePlotData';
@@ -30,9 +30,7 @@ export default defineComponent({
   },
   components: { ScreePlot, VisTile },
   setup(props) {
-    // TODO this won't be necessary in Vue 3
-    const id = computed(() => props.id);
-    const { plot } = usePlotData(id, 'pca');
+    const { plot } = usePlotData(toRef(props, 'id'), 'pca');
     return { plot };
   },
 });

--- a/web/src/components/vis/ScreePlotTile.vue
+++ b/web/src/components/vis/ScreePlotTile.vue
@@ -1,5 +1,7 @@
 <script lang="ts">
-import { defineComponent, computed, ref } from '@vue/composition-api';
+import {
+  defineComponent, computed, ref, toRef,
+} from '@vue/composition-api';
 import ScreePlot from '@/components/vis/ScreePlot.vue';
 import VisTile from '@/components/vis/VisTile.vue';
 import usePlotData from './use/usePlotData';
@@ -15,13 +17,11 @@ export default defineComponent({
   components: { ScreePlot, VisTile },
 
   setup(props) {
-    // TODO this won't be necessary in Vue 3
-    const id = computed(() => props.id);
     const showCutoffs = ref(true);
     const numComponentsText = ref('10');
     const numComponents = computed(() => Number.parseInt(numComponentsText.value, 10));
 
-    const { plot } = usePlotData(id, 'pca');
+    const { plot } = usePlotData(toRef(props, 'id'), 'pca');
 
     return {
       numComponentsText,


### PR DESCRIPTION
There are some cases where a prop must be passed as a reactive value to
a child component. Since individual props aren't reactive, the initial
solution was to wrap them in a computed property. I have since been
pointed to `toRef`, which solves this exact problem.