### PR TITLE
Fix auto converted &amp; in pug templates

### DIFF
--- a/web/src/components/vis/Heatmap.vue
+++ b/web/src/components/vis/Heatmap.vue
@@ -737,7 +737,7 @@ export default {
       :data-update="reactiveRowLabelUpdate"
     />
     <div
-      v-show="columnConfig.dendrogram &amp;&amp; rowConfig.dendrogram"
+      v-show="columnConfig.dendrogram && rowConfig.dendrogram"
       class="legend-wrapper"
     >
       <div

--- a/web/src/components/vis/PcaPage/PcaPage.vue
+++ b/web/src/components/vis/PcaPage/PcaPage.vue
@@ -102,7 +102,7 @@ export default defineComponent({
               label="PC (X Axis)"
               min="1"
               outline="outline"
-              :disabled="!showScore &amp;&amp; !showLoadings"
+              :disabled="!showScore && !showLoadings"
             />
             <v-text-field
               v-model="pcYval"
@@ -112,7 +112,7 @@ export default defineComponent({
               label="PC (Y Axis)"
               min="1"
               outline="outline"
-              :disabled="!showScore &amp;&amp; !showLoadings"
+              :disabled="!showScore && !showLoadings"
             />
           </v-layout>
         </v-card-actions>


### PR DESCRIPTION
The pug autoconverter I was using converted the `&`s in boolean
statements like:
```
:disabled="!showScore && !showLoadings"
```
to:
```
:disabled="!showScore &amp;&amp; !showLoadings"
```
This passed linting for some reason.