### PR TITLE
Add server support for oplsda analysis

### DIFF
--- a/devops/Dockerfile.base
+++ b/devops/Dockerfile.base
@@ -37,5 +37,6 @@ RUN R -e 'require(devtools); install_version("mnormt", version = "1.5-6")'
 RUN R -e 'install.packages("psych")'
 RUN R -e 'install.packages("pROC")'
 RUN R -e 'BiocManager::install("mixOmics", version = "3.9")'
+RUN R -e 'BiocManager::install("ropls", version = "3.9")'
 ADD viime /viime
 RUN R -e 'setwd("/viime"); devtools::update_packages(devtools::dev_package_deps()$package, dependencies=NA, upgrade="never");' && rm -fr /viime

--- a/devops/viime/R/analyses.R
+++ b/devops/viime/R/analyses.R
@@ -320,3 +320,46 @@ plsda <- function(measurements, groups, num_of_components, mode) {
     stop("Invalid mode for PLSDA.")
   }
 }
+
+#' oplsda
+#'
+#' @export
+oplsda <- function(measurements, groups, mode) {
+  library(ropls)
+  df <- read.csv(measurements, row.names=1, check.names=FALSE)
+  groups <- read.csv(groups, row.names=1, check.names=FALSE)
+  groups <- as.factor(groups[,1])
+
+  # Perform OPLS-DA
+  ropls_oplsda <- ropls::opls(df, groups, scaleC="none", orthoI=NA)
+
+  if (mode == "scores") {
+    #Main Score
+    ropls_scores_x  <- as.data.frame(ropls_oplsda@scoreMN)
+    #Orthogonal
+    ropls_scores_y  <- as.data.frame(ropls_oplsda@orthoScoreMN)
+    #Save scores together
+    oplsda_scores <- cbind(ropls_scores_x , ropls_scores_y)
+
+    return(oplsda_scores)
+  } else if (mode == "loadings") {
+    # Save loadings
+    #Main loadings
+    ropls_loadings_x  <- as.data.frame(ropls_oplsda@loadingMN)
+    #Orthogonal loadings
+    ropls_loadings_y  <- as.data.frame(ropls_oplsda@orthoLoadingMN)
+    #Save loadings together
+    oplsda_loadings <- cbind(ropls_loadings_x , ropls_loadings_y)
+
+    return(oplsda_loadings)
+  } else if (mode == "vip") {
+    #VIP Scores
+    ropls_vip <- as.data.frame(ropls_oplsda@vipVn)
+
+    return(ropls_vip)
+  } else if (mode == "modeldf") {
+    return(ropls_oplsda@modelDF)
+  } else {
+    stop("Invalid mode for PLSDA.")
+  }
+}

--- a/viime/analyses.py
+++ b/viime/analyses.py
@@ -128,3 +128,14 @@ def plsda(measurements: pd.DataFrame, groups: pd.DataFrame, num_of_components: i
         'mode': mode
     })
     return clean(data).to_dict(orient='list')
+
+
+def oplsda(measurements: pd.DataFrame, groups: pd.DataFrame, mode='scores'):
+    files = {
+        'measurements': measurements.to_csv().encode(),
+        'groups': groups.to_csv(header=True).encode()
+    }
+    data = opencpu_request('oplsda', files, {
+        'mode': mode
+    })
+    return clean(data).to_dict(orient='list')


### PR DESCRIPTION
This returns data that should be compatible with the plsda endpoint.  The only thing I'm unsure about is the "explained variance" or "sdev" that gets returned with the scores.  Lilian's comment in the example code states that `R2Y` is "R2 for main axis", so my assumption is that "sdev" should be the square root of that value, but it should be verified.
