### PR TITLE
Plsda improvements

### DIFF
--- a/devops/viime/R/analyses.R
+++ b/devops/viime/R/analyses.R
@@ -316,6 +316,22 @@ plsda <- function(measurements, groups, num_of_components, mode) {
     # Save loadings
     load_plsda <- as.data.frame(mod_plsda$loadings$X)
     return(load_plsda)
+  } else if (mode == "vip") {
+    # VIP scores/vip
+    vip <- vip(mod_plsda)
+    return(vip)
+  } else if (mode == "r2") {
+    # R2 values
+    Group_num <- as.numeric(as.factor(groups))
+    mod_pls <- mixOmics::pls(df, Group_num, scale=FALSE, ncomp = num_of_components)
+    qr <- mixOmics::perf(mod_pls, validation='loo')
+    return(qr$R2)
+  } else if (mode == "q2") {
+    # Q2 values
+    Group_num <- as.numeric(as.factor(groups))
+    mod_pls <- mixOmics::pls(df, Group_num, scale=FALSE, ncomp = num_of_components)
+    qr <- mixOmics::perf(mod_pls, validation='loo')
+    return(qr$Q2)
   } else {
     stop("Invalid mode for PLSDA.")
   }
@@ -324,14 +340,14 @@ plsda <- function(measurements, groups, num_of_components, mode) {
 #' oplsda
 #'
 #' @export
-oplsda <- function(measurements, groups, mode) {
+oplsda <- function(measurements, groups, num_of_components, mode) {
   library(ropls)
   df <- read.csv(measurements, row.names=1, check.names=FALSE)
   groups <- read.csv(groups, row.names=1, check.names=FALSE)
   groups <- as.factor(groups[,1])
 
   # Perform OPLS-DA
-  ropls_oplsda <- ropls::opls(df, groups, scaleC="none", orthoI=NA)
+  ropls_oplsda <- ropls::opls(df, groups, scaleC="none", orthoI=num_of_components)
 
   if (mode == "scores") {
     #Main Score
@@ -355,10 +371,11 @@ oplsda <- function(measurements, groups, mode) {
   } else if (mode == "vip") {
     #VIP Scores
     ropls_vip <- as.data.frame(ropls_oplsda@vipVn)
-
     return(ropls_vip)
   } else if (mode == "modeldf") {
     return(ropls_oplsda@modelDF)
+  } else if (mode == "summarydf") {
+    return(ropls_oplsda@summaryDF)
   } else {
     stop("Invalid mode for PLSDA.")
   }

--- a/tests/test_analyses.py
+++ b/tests/test_analyses.py
@@ -88,36 +88,14 @@ def test_plsda(client, test_dataset):
     ]
     rows = [row for row in rows if row['row_type'] == 'sample']
 
-    # perform PLSDA with no `num_of_components` parameter
-    data = {}
-    resp = client.get(url_for('csv.get_plsda', csv_id=str(csv_id)), json=data)
-    assert resp.status_code == 200
-    keys = {'scores', 'loadings', 'rows', 'labels'}
-    assert keys == set(resp.json.keys())
-
-    num_of_components = min(len(columns), len(rows))  # default num_of_components
-
-    loadings = resp.json.get('loadings')
-    for loading in loadings:
-        assert loading.get('col') in columns
-        assert loading.get('loadings') is not None
-
-        assert len(loading.get('loadings')) == num_of_components
-
-    scores = resp.json.get('scores')
-
-    assert 'sdev' in scores.keys()
-    assert len(scores.get('sdev')) == num_of_components
-    assert 'x' in scores.keys()
-    assert len(scores.get('x')) == len(rows)
-
-    for x in scores.get('x'):
-        assert len(x) == num_of_components
-
     # perform PLSDA with `num_of_components` = 10
     num_of_components = 10
     data = {'num_of_components': num_of_components}
     resp = client.get(url_for('csv.get_plsda', csv_id=str(csv_id)), json=data)
+    assert resp.status_code == 200
+    keys = {'scores', 'loadings', 'rows', 'labels', 'r2', 'q2'}
+    assert keys == set(resp.json.keys())
+
     loadings = resp.json.get('loadings')
     for loading in loadings:
         assert loading.get('col') in columns

--- a/viime/analyses.py
+++ b/viime/analyses.py
@@ -130,12 +130,13 @@ def plsda(measurements: pd.DataFrame, groups: pd.DataFrame, num_of_components: i
     return clean(data).to_dict(orient='list')
 
 
-def oplsda(measurements: pd.DataFrame, groups: pd.DataFrame, mode='scores'):
+def oplsda(measurements: pd.DataFrame, groups: pd.DataFrame, num_of_components: int, mode='scores'):
     files = {
         'measurements': measurements.to_csv().encode(),
         'groups': groups.to_csv(header=True).encode()
     }
     data = opencpu_request('oplsda', files, {
+        'num_of_components': num_of_components,
         'mode': mode
     })
     return clean(data).to_dict(orient='list')

--- a/viime/views.py
+++ b/viime/views.py
@@ -727,7 +727,7 @@ def get_pca_overview(validated_table: ValidatedMetaboliteTable):
 
 @csv_bp.route('/csv/<uuid:csv_id>/analyses/plsda', methods=['GET'])
 @use_kwargs({
-    'num_of_components': fields.Integer(required=True)
+    'num_of_components': fields.Integer(required=False)
 })
 @load_validated_csv_file
 def get_plsda(validated_table: ValidatedMetaboliteTable, num_of_components: Optional[int] = 3):
@@ -745,7 +745,7 @@ def get_plsda(validated_table: ValidatedMetaboliteTable, num_of_components: Opti
 
     scores = plsda(measurements, groups, num_of_components, 'scores')
     loadings = plsda(measurements, groups, num_of_components, 'loadings')
-    vip = plsda(measurements, groups, num_of_components, 'vip')
+    # TODO vip = plsda(measurements, groups, num_of_components, 'vip')
     r2 = plsda(measurements, groups, num_of_components, 'r2')
     q2 = plsda(measurements, groups, num_of_components, 'q2')
 

--- a/web/src/components/vis/OplsdaPage/OplsdaPage.vue
+++ b/web/src/components/vis/OplsdaPage/OplsdaPage.vue
@@ -2,7 +2,7 @@
 import VisTileLarge from '@/components/vis/VisTileLarge.vue';
 import LayoutGrid from '@/components/LayoutGrid.vue';
 import {
-  computed, defineComponent, reactive, toRef, toRefs, watchEffect,
+  computed, ComputedRef, defineComponent, reactive, toRef, watch, watchEffect,
 } from '@vue/composition-api';
 import ScorePlot from './ScorePlot.vue';
 import LoadingsPlot from './LoadingsPlot.vue';
@@ -26,7 +26,9 @@ export default defineComponent({
     const { dataset, plot, changePlotArgs } = usePlotData(toRef(props, 'id'), 'oplsda');
     const controls = reactive({
       pcYval: '1',
+      numComponentsVal: '3',
       pcY: 2,
+      numComponents: 3,
       showEllipses: true,
       showCrosshairs: true,
       showCutoffs: true,
@@ -39,7 +41,16 @@ export default defineComponent({
       const loadingsReady = store.getters.ready(props.id, 'plsda_loadings');
       return pcaReady && loadingsReady;
     });
-    const r2 = computed(() => plot.value.data?.r2 || []);
+    const r2: ComputedRef<number[]> = computed(() => plot.value.data?.r2 || []);
+    const q2: ComputedRef<number[]> = computed(() => plot.value.data?.q2 || []);
+    const r2q2Table = computed(() => r2.value.map((r2Val, i) => {
+      if (i === 0) {
+        return { name: 'P', r2: r2Val.toFixed(3), q2: q2.value[i].toFixed(3) };
+      }
+      return {
+        name: `O${i}`, r2: r2Val.toFixed(3), q2: q2.value[i].toFixed(3), index: i,
+      };
+    }));
     const loadings = computed(() => plot.value.data?.loadings || []);
     const pcCoords = computed(() => plot.value.data?.scores.x || []);
     const eigenvalues = computed(() => plot.value.data?.scores.sdev || []);
@@ -50,10 +61,20 @@ export default defineComponent({
 
     watchEffect(() => {
       const pcY = Number.parseInt(controls.pcYval, 10);
-      if (!Number.isNaN(pcY)) {
+      if (!Number.isNaN(pcY) && pcY <= controls.numComponents) {
         // The first of the 6 components is always pcX
         // We want to express pcY as an integer in [1..5], but use it as a number in [2..6]
         controls.pcY = pcY + 1;
+      }
+    });
+    watch(() => controls.numComponentsVal, () => {
+      const numComponents = Number.parseInt(controls.numComponentsVal, 10);
+      if (!Number.isNaN(numComponents)) {
+        controls.numComponents = numComponents;
+        if (plot.value) {
+          plot.value.valid = false;
+        }
+        changePlotArgs({ num_of_components: controls.numComponents });
       }
     });
 
@@ -63,6 +84,7 @@ export default defineComponent({
       controls,
       ready,
       r2,
+      r2q2Table,
       loadings,
       pcCoords,
       eigenvalues,
@@ -88,6 +110,34 @@ export default defineComponent({
         flat="flat"
         dense="dense"
       >
+        <v-toolbar-title>Components</v-toolbar-title>
+      </v-toolbar>
+      <v-card
+        class="mb-3 mx-3"
+        flat
+      >
+        <v-card-actions>
+          <v-layout column>
+            <v-text-field
+              v-model="controls.numComponentsVal"
+              class="py-2"
+              hide-details
+              type="number"
+              min="1"
+              outline
+              :disabled="plot.loading"
+              label="Number of Components"
+            />
+          </v-layout>
+        </v-card-actions>
+      </v-card>
+      <v-toolbar
+        class="darken-3"
+        color="primary"
+        dark
+        flat
+        dense
+      >
         <v-toolbar-title>PC selector</v-toolbar-title>
       </v-toolbar>
       <v-card
@@ -101,7 +151,7 @@ export default defineComponent({
               class="py-2"
               hide-details="hide-details"
               type="number"
-              label="O (Y Axis)"
+              label="Orthogonal (Y Axis)"
               min="1"
               max="5"
               outline="outline"
@@ -110,20 +160,29 @@ export default defineComponent({
           </v-layout>
         </v-card-actions>
         <v-card-text class="subheading">
-          <div
-            v-for="(r2Val,index) in r2"
-            :key="index"
-            :class="(index===controls.pcY-1)? 'font-weight-bold':''"
-            @click="if (index !== 0) controls.pcYval=index"
-          >
-            <template v-if="index === 0">
-              P
-            </template>
-            <template v-else>
-              O{{ index }}
-            </template>
-            R<sup>2</sup>: {{ r2Val }}
-          </div>
+          <table>
+            <tbody>
+              <tr>
+                <th class="px-3" />
+                <th class="px-3">
+                  R<sup>2</sup>
+                </th>
+                <th class="px-3">
+                  Q<sup>2</sup>
+                </th>
+              </tr>
+              <tr
+                v-for="pc in r2q2Table"
+                :key="pc.name"
+                :class="(pc.index===controls.pcY-1)? 'font-weight-bold':''"
+                @click="if (pc.index) controls.pcYval=pc.index"
+              >
+                <td>{{ pc.name }}</td>
+                <td>{{ pc.r2 }}</td>
+                <td>{{ pc.q2 }}</td>
+              </tr>
+            </tbody>
+          </table>
         </v-card-text>
       </v-card>
       <v-toolbar

--- a/web/src/components/vis/PlsdaPage/PlsdaPage.vue
+++ b/web/src/components/vis/PlsdaPage/PlsdaPage.vue
@@ -151,6 +151,7 @@ export default defineComponent({
               type="number"
               label="PC (X Axis)"
               min="1"
+              :max="controls.numComponents"
               outline="outline"
               :disabled="!controls.showScore && !controls.showLoadings"
             />
@@ -161,6 +162,7 @@ export default defineComponent({
               type="number"
               label="PC (Y Axis)"
               min="1"
+              :max="controls.numComponents"
               outline="outline"
               :disabled="!controls.showScore && !controls.showLoadings"
             />

--- a/web/src/components/vis/PlsdaPage/PlsdaPage.vue
+++ b/web/src/components/vis/PlsdaPage/PlsdaPage.vue
@@ -2,7 +2,7 @@
 import VisTileLarge from '@/components/vis/VisTileLarge.vue';
 import LayoutGrid from '@/components/LayoutGrid.vue';
 import {
-  computed, defineComponent, reactive, toRef, toRefs, watchEffect,
+  computed, ComputedRef, defineComponent, reactive, toRef, watch, watchEffect,
 } from '@vue/composition-api';
 import ScorePlot from './ScorePlot.vue';
 import LoadingsPlot from './LoadingsPlot.vue';
@@ -27,10 +27,10 @@ export default defineComponent({
     const controls = reactive({
       pcXval: '1',
       pcYval: '2',
-      numComponentsVal: '10',
+      numComponentsVal: '3',
       pcX: 1,
       pcY: 2,
-      numComponents: 10,
+      numComponents: 3,
       showEllipses: true,
       showCrosshairs: true,
       showCutoffs: true,
@@ -43,6 +43,9 @@ export default defineComponent({
       const loadingsReady = store.getters.ready(props.id, 'plsda_loadings');
       return pcaReady && loadingsReady;
     });
+    const r2: ComputedRef<number[]> = computed(() => plot.value.data?.r2 || []);
+    const q2: ComputedRef<number[]> = computed(() => plot.value.data?.q2 || []);
+    const r2q2Table = computed(() => r2.value.map((r2Val, i) => ({ name: `PC${i + 1}`, r2: r2Val.toFixed(3), q2: q2.value[i].toFixed(3) })));
     const loadings = computed(() => plot.value.data?.loadings || []);
     const pcCoords = computed(() => plot.value.data?.scores.x || []);
     const eigenvalues = computed(() => plot.value.data?.scores.sdev || []);
@@ -53,20 +56,24 @@ export default defineComponent({
 
     watchEffect(() => {
       const pcX = Number.parseInt(controls.pcXval, 10);
-      if (!Number.isNaN(pcX)) {
+      if (!Number.isNaN(pcX) && pcX <= controls.numComponents) {
         controls.pcX = pcX;
       }
     });
     watchEffect(() => {
       const pcY = Number.parseInt(controls.pcYval, 10);
-      if (!Number.isNaN(pcY)) {
+      if (!Number.isNaN(pcY) && pcY <= controls.numComponents) {
         controls.pcY = pcY;
       }
     });
-    watchEffect(() => {
+    watch(() => controls.numComponentsVal, () => {
       const numComponents = Number.parseInt(controls.numComponentsVal, 10);
       if (!Number.isNaN(numComponents)) {
         controls.numComponents = numComponents;
+        if (plot.value) {
+          plot.value.valid = false;
+        }
+        changePlotArgs({ num_of_components: controls.numComponents });
       }
     });
 
@@ -76,6 +83,7 @@ export default defineComponent({
       controls,
       ready,
       loadings,
+      r2q2Table,
       pcCoords,
       eigenvalues,
       rowLabels,
@@ -117,7 +125,6 @@ export default defineComponent({
               outline="outline"
               :disabled="plot.loading"
               label="Number of Components"
-              @change="plot.valid=false;changePlotArgs({ num_of_components: $event });"
             />
           </v-layout>
         </v-card-actions>
@@ -159,6 +166,29 @@ export default defineComponent({
             />
           </v-layout>
         </v-card-actions>
+        <v-card-text class="subheading">
+          <table>
+            <tbody>
+              <tr>
+                <th class="px-3" />
+                <th class="px-3">
+                  R<sup>2</sup>
+                </th>
+                <th class="px-3">
+                  Q<sup>2</sup>
+                </th>
+              </tr>
+              <tr
+                v-for="pc in r2q2Table"
+                :key="pc.name"
+              >
+                <td>{{ pc.name }}</td>
+                <td>{{ pc.r2 }}</td>
+                <td>{{ pc.q2 }}</td>
+              </tr>
+            </tbody>
+          </table>
+        </v-card-text>
       </v-card>
       <v-toolbar
         class="darken-3"

--- a/web/src/store/index.js
+++ b/web/src/store/index.js
@@ -108,14 +108,18 @@ const plotDefaults = {
     data: null,
     valid: false,
     loading: false,
-    args: {},
+    args: {
+      num_of_components: 3,
+    },
     type: plot_types.ANALYSIS,
   },
   oplsda: {
     data: null,
     valid: false,
     loading: false,
-    args: {},
+    args: {
+      num_of_components: 3,
+    },
     type: plot_types.ANALYSIS,
   },
   boxplot: {


### PR DESCRIPTION
Backend changes:
* Add VIP scores to PLSDA and OPLSDA in analysis.R
* Add num_of_components to OPLSDA to match PLSDA
* Add Q^2 values to OPLSDA
* Add R^2 and Q^2 values to PLSDA to match OPLSDA
* Pass all those new values through the views
* Make num_of_components default to 3 everywhere and make it non-optional
Cumulative R^2/Q^2 values were added OPLSDA because they were provided, but aren't being rendered in the frontend.

Frontend changes:
* Give OPLSDA a num_of_compenents field to match PLSDA
* Render R^2 and Q^2 under the PC selector for both PLSDA and OPLSDA
* Rework the `watch` statement for number_of_components to properly cause the plot to re-render
* Default num_of_components to 3
