### PR TITLE
Add group selectors to OPLSDA

### DIFF
--- a/viime/views.py
+++ b/viime/views.py
@@ -806,8 +806,10 @@ def get_oplsda(validated_table: ValidatedMetaboliteTable,
     group_column_name = groups.columns[0]
     # Initial page loads will not have groups selected yet, so default to the first two groups
     if group1 is None and group2 is None:
-        group1 = groups[group_column_name].unique()[0]
-        group2 = groups[group_column_name].unique()[1]
+        group_names = groups[group_column_name].unique()
+        group_names.sort()
+        group1 = group_names[0]
+        group2 = group_names[1]
 
     # Filter groups and measurements by the selected groups
     groups = groups.loc[groups[group_column_name].isin((group1, group2))]

--- a/viime/views.py
+++ b/viime/views.py
@@ -791,13 +791,24 @@ def get_plsda(validated_table: ValidatedMetaboliteTable, num_of_components: Opti
 
 @csv_bp.route('/csv/<uuid:csv_id>/analyses/oplsda', methods=['GET'])
 @use_kwargs({
-    'num_of_components': fields.Integer(required=True)
+    'num_of_components': fields.Integer(required=True),
+    'group1': fields.String(required=False),
+    'group2': fields.String(required=False),
 })
 @load_validated_csv_file
-def get_oplsda(validated_table: ValidatedMetaboliteTable, num_of_components: Optional[int] = 3):
+def get_oplsda(validated_table: ValidatedMetaboliteTable, num_of_components: Optional[int] = 3, group1: Optional[str] = None, group2: Optional[str] = None):
 
     measurements = validated_table.measurements
     groups = validated_table.groups
+    group_column_name = groups.columns[0]
+    # Initial page loads will not have groups selected yet, so default to the first two groups
+    if group1 == None and group2 == None:
+        group1 = groups[group_column_name].unique()[0]
+        group2 = groups[group_column_name].unique()[1]
+
+    # Filter groups and measurements by the selected groups
+    groups = groups.loc[groups[group_column_name].isin((group1, group2))]
+    measurements = measurements.loc[measurements.index.intersection(groups.index)]
 
     scores = oplsda(measurements, groups, num_of_components, 'scores')
     loadings = oplsda(measurements, groups, num_of_components, 'loadings')

--- a/viime/views.py
+++ b/viime/views.py
@@ -796,13 +796,16 @@ def get_plsda(validated_table: ValidatedMetaboliteTable, num_of_components: Opti
     'group2': fields.String(required=False),
 })
 @load_validated_csv_file
-def get_oplsda(validated_table: ValidatedMetaboliteTable, num_of_components: Optional[int] = 3, group1: Optional[str] = None, group2: Optional[str] = None):
+def get_oplsda(validated_table: ValidatedMetaboliteTable,
+               num_of_components: Optional[int] = 3,
+               group1: Optional[str] = None,
+               group2: Optional[str] = None):
 
     measurements = validated_table.measurements
     groups = validated_table.groups
     group_column_name = groups.columns[0]
     # Initial page loads will not have groups selected yet, so default to the first two groups
-    if group1 == None and group2 == None:
+    if group1 is None and group2 is None:
         group1 = groups[group_column_name].unique()[0]
         group2 = groups[group_column_name].unique()[1]
 

--- a/web/src/components/vis/OplsdaPage/OplsdaPage.vue
+++ b/web/src/components/vis/OplsdaPage/OplsdaPage.vue
@@ -60,7 +60,7 @@ export default defineComponent({
     const groupLabels = computed(() => plot.value.data?.labels || {});
     const columns = computed(() => dataset.value?.column.data || []);
     const groupLevels = computed(() => dataset.value?.groupLevels || []);
-    const groupNames = computed(() => groupLevels.value.map((level) => level.name));
+    const groupNames = computed(() => groupLevels.value.map((level: { name: string }) => level.name));
 
     watchEffect(() => {
       const pcY = Number.parseInt(controls.pcYval, 10);

--- a/web/src/components/vis/OplsdaPage/OplsdaPage.vue
+++ b/web/src/components/vis/OplsdaPage/OplsdaPage.vue
@@ -34,6 +34,8 @@ export default defineComponent({
       showCutoffs: true,
       showScore: true,
       showLoadings: true,
+      group1: dataset.value?.groupLevels[0]?.name || '',
+      group2: dataset.value?.groupLevels[1]?.name || '',
     });
 
     const ready = computed(() => {
@@ -58,6 +60,7 @@ export default defineComponent({
     const groupLabels = computed(() => plot.value.data?.labels || {});
     const columns = computed(() => dataset.value?.column.data || []);
     const groupLevels = computed(() => dataset.value?.groupLevels || []);
+    const groupNames = computed(() => groupLevels.value.map(level => level.name));
 
     watchEffect(() => {
       const pcY = Number.parseInt(controls.pcYval, 10);
@@ -78,6 +81,37 @@ export default defineComponent({
       }
     });
 
+    // These two watchers prevent the same group from being selected twice.
+    watch(() => controls.group1, (newGroup, oldGroup) => {
+      changePlotArgs({ group1: newGroup });
+      // When setting the same group twice, switch them instead
+      if (controls.group2 === newGroup) {
+        controls.group2 = oldGroup;
+        changePlotArgs({ group2: oldGroup });
+      }
+      if (plot.value) {
+        plot.value.valid = false;
+      }
+    });
+    watch(() => controls.group2, (newGroup, oldGroup) => {
+      changePlotArgs({ group2: newGroup });
+      // When setting the same group twice, switch them instead
+      if (controls.group1 === newGroup) {
+        controls.group1 = oldGroup;
+        changePlotArgs({ group1: oldGroup });
+      }
+      if (plot.value) {
+        plot.value.valid = false;
+      }
+    });
+
+    // If no groups are selected after the plot loads, select the first two groups
+    watch(() => dataset.value, () => {
+      controls.group1 = dataset.value?.groupLevels[0]?.name || '';
+      controls.group2 = dataset.value?.groupLevels[1]?.name || '';
+      changePlotArgs({ group1: controls.group1, group2: controls.group2 });
+    })
+
     return {
       plot,
       changePlotArgs,
@@ -92,6 +126,7 @@ export default defineComponent({
       groupLabels,
       columns,
       groupLevels,
+      groupNames,
     };
   },
 });
@@ -153,7 +188,7 @@ export default defineComponent({
               type="number"
               label="Orthogonal (Y Axis)"
               min="1"
-              max="5"
+              :max="controls.numComponents"
               outline
               :disabled="!controls.showScore && !controls.showLoadings"
             />
@@ -188,10 +223,58 @@ export default defineComponent({
       <v-toolbar
         class="darken-3"
         color="primary"
+        <<<<<<<
+        Updated
+        upstream
         dark
         flat
-        dense
+        dense=======dark="dark"
+        flat="flat"
+        dense="dense"
+        :card="false"
       >
+        <v-toolbar-title>Group 1</v-toolbar-title>
+      </v-toolbar>
+      <v-card
+        class="mx-3 px-2"
+        flat="flat"
+      >
+        <v-select
+          v-model="controls.group1"
+          class="py-2"
+          hide-details="hide-details"
+          :items="groupNames"
+        />
+      </v-card>
+      <v-toolbar
+        class="darken-3"
+        color="primary"
+        dark="dark"
+        flat="flat"
+        dense="dense"
+        :card="false"
+      >
+        <v-toolbar-title>Group 2</v-toolbar-title>
+      </v-toolbar>
+      <v-card
+        class="mx-3 px-2"
+        flat="flat"
+      >
+        <v-select
+          v-model="controls.group2"
+          class="py-2"
+          hide-details="hide-details"
+          :items="groupNames"
+        />
+      </v-card>
+      <v-toolbar
+        class="darken-3"
+        color="primary"
+        dark="dark"
+        flat="flat"
+        dense="dense"
+      >>>>>>> Stashed changes
+        >
         <v-toolbar-title class="switch-title">
           Score Plot
           <v-switch

--- a/web/src/components/vis/OplsdaPage/OplsdaPage.vue
+++ b/web/src/components/vis/OplsdaPage/OplsdaPage.vue
@@ -60,7 +60,9 @@ export default defineComponent({
     const groupLabels = computed(() => plot.value.data?.labels || {});
     const columns = computed(() => dataset.value?.column.data || []);
     const groupLevels = computed(() => dataset.value?.groupLevels || []);
-    const groupNames = computed(() => groupLevels.value.map((level: { name: string }) => level.name));
+    const groupNames = computed(() => groupLevels.value.map(
+      (level: { name: string }) => level.name,
+    ));
 
     watchEffect(() => {
       const pcY = Number.parseInt(controls.pcYval, 10);

--- a/web/src/components/vis/OplsdaPage/OplsdaPage.vue
+++ b/web/src/components/vis/OplsdaPage/OplsdaPage.vue
@@ -34,8 +34,8 @@ export default defineComponent({
       showCutoffs: true,
       showScore: true,
       showLoadings: true,
-      group1: dataset.value?.groupLevels[0]?.name || '',
-      group2: dataset.value?.groupLevels[1]?.name || '',
+      group1: dataset.value?.groupLevels[0]?.name || null,
+      group2: dataset.value?.groupLevels[1]?.name || null,
     });
 
     const ready = computed(() => {
@@ -58,7 +58,7 @@ export default defineComponent({
     const eigenvalues = computed(() => plot.value.data?.scores.sdev || []);
     const rowLabels = computed(() => plot.value.data?.rows || []);
     const groupLabels = computed(() => plot.value.data?.labels || {});
-    const columns = computed(() => dataset.value?.column.data || []);
+    const columns = computed(() => dataset.value?.column?.data || []);
     const groupLevels = computed(() => dataset.value?.groupLevels || []);
     const groupNames = computed(() => groupLevels.value.map(
       (level: { name: string }) => level.name,
@@ -91,7 +91,8 @@ export default defineComponent({
         controls.group2 = oldGroup;
         changePlotArgs({ group2: oldGroup });
       }
-      if (plot.value) {
+      // only force a refresh if both groups are set
+      if (plot.value && controls.group1 && controls.group2) {
         plot.value.valid = false;
       }
     });
@@ -102,16 +103,10 @@ export default defineComponent({
         controls.group1 = oldGroup;
         changePlotArgs({ group1: oldGroup });
       }
-      if (plot.value) {
+      // only force a refresh if both groups are set
+      if (plot.value && controls.group1 && controls.group2) {
         plot.value.valid = false;
       }
-    });
-
-    // If no groups are selected after the plot loads, select the first two groups
-    watch(() => dataset.value, () => {
-      controls.group1 = dataset.value?.groupLevels[0]?.name || '';
-      controls.group2 = dataset.value?.groupLevels[1]?.name || '';
-      changePlotArgs({ group1: controls.group1, group2: controls.group2 });
     });
 
     return {

--- a/web/src/components/vis/OplsdaPage/OplsdaPage.vue
+++ b/web/src/components/vis/OplsdaPage/OplsdaPage.vue
@@ -60,7 +60,7 @@ export default defineComponent({
     const groupLabels = computed(() => plot.value.data?.labels || {});
     const columns = computed(() => dataset.value?.column.data || []);
     const groupLevels = computed(() => dataset.value?.groupLevels || []);
-    const groupNames = computed(() => groupLevels.value.map(level => level.name));
+    const groupNames = computed(() => groupLevels.value.map((level) => level.name));
 
     watchEffect(() => {
       const pcY = Number.parseInt(controls.pcYval, 10);
@@ -110,7 +110,7 @@ export default defineComponent({
       controls.group1 = dataset.value?.groupLevels[0]?.name || '';
       controls.group2 = dataset.value?.groupLevels[1]?.name || '';
       changePlotArgs({ group1: controls.group1, group2: controls.group2 });
-    })
+    });
 
     return {
       plot,
@@ -223,14 +223,9 @@ export default defineComponent({
       <v-toolbar
         class="darken-3"
         color="primary"
-        <<<<<<<
-        Updated
-        upstream
         dark
         flat
-        dense=======dark="dark"
-        flat="flat"
-        dense="dense"
+        dense
         :card="false"
       >
         <v-toolbar-title>Group 1</v-toolbar-title>
@@ -273,8 +268,7 @@ export default defineComponent({
         dark="dark"
         flat="flat"
         dense="dense"
-      >>>>>>> Stashed changes
-        >
+      >
         <v-toolbar-title class="switch-title">
           Score Plot
           <v-switch


### PR DESCRIPTION
Now arbitrary datasets can be used with OPLSDA, as long as they have two or more groups defined.

I found an example of doing the group filtering in R, but I don't know how to write/debug R so I implemented it in the python view instead.