### PR TITLE
Fix google analytics initialization

### DIFF
--- a/web/src/main.ts
+++ b/web/src/main.ts
@@ -47,6 +47,7 @@ if (process.env.CONTEXT === 'production') {
 Vue.use(VueGtag, {
   config: { id: process.env.VUE_APP_GOOGLE_ANALYTICS_ID },
   enabled: process.env.NODE_ENV === 'production' && process.env.VUE_APP_GOOGLE_ANALYTICS_ID,
+  includes: [{ id: process.env.VUE_APP_GOOGLE_ANALYTICS_ID }],
 }, router);
 
 new Vue({


### PR DESCRIPTION
This isn't terribly well documented anywhere, but I found if you leave out the `includes` option, it doesn't trigger the config event and no events are sent to Google.