### PR TITLE
VIP Scores plot

### DIFF
--- a/tests/test_analyses.py
+++ b/tests/test_analyses.py
@@ -93,7 +93,7 @@ def test_plsda(client, test_dataset):
     data = {'num_of_components': num_of_components}
     resp = client.get(url_for('csv.get_plsda', csv_id=str(csv_id)), json=data)
     assert resp.status_code == 200
-    keys = {'scores', 'loadings', 'rows', 'labels', 'r2', 'q2'}
+    keys = {'scores', 'loadings', 'vip_scores', 'rows', 'labels', 'r2', 'q2'}
     assert keys == set(resp.json.keys())
 
     loadings = resp.json.get('loadings')

--- a/viime/views.py
+++ b/viime/views.py
@@ -745,7 +745,7 @@ def get_plsda(validated_table: ValidatedMetaboliteTable, num_of_components: Opti
 
     scores = plsda(measurements, groups, num_of_components, 'scores')
     loadings = plsda(measurements, groups, num_of_components, 'loadings')
-    # TODO vip = plsda(measurements, groups, num_of_components, 'vip')
+    vip_scores = plsda(measurements, groups, num_of_components, 'vip')
     r2 = plsda(measurements, groups, num_of_components, 'r2')
     q2 = plsda(measurements, groups, num_of_components, 'q2')
 
@@ -766,6 +766,14 @@ def get_plsda(validated_table: ValidatedMetaboliteTable, num_of_components: Opti
                 formatted_loadings[j]['loadings'] = []
             formatted_loadings[j]['loadings'].append(loading)
 
+    formatted_vip_scores = [
+        [
+            {'col': column_names[j], 'vip': vip}
+            for j, vip in enumerate(vip_scores[f'comp{i}'])
+        ]
+        for i in range(1, num_of_components + 1)
+    ]
+
     explained_variances = [
         scores.get(f'explained_variance.comp.{i+1}')[0] for i in range(num_of_components)
     ]
@@ -782,6 +790,7 @@ def get_plsda(validated_table: ValidatedMetaboliteTable, num_of_components: Opti
     return jsonify({
         'scores': formatted_scores,
         'loadings': formatted_loadings,
+        'vip_scores': formatted_vip_scores,
         'labels': labels,
         'rows': rows,
         'r2': formatted_r2,
@@ -815,7 +824,7 @@ def get_oplsda(validated_table: ValidatedMetaboliteTable,
 
     scores = oplsda(measurements, groups, num_of_components, 'scores')
     loadings = oplsda(measurements, groups, num_of_components, 'loadings')
-    vip = oplsda(measurements, groups, num_of_components, 'vip')
+    vip_scores = oplsda(measurements, groups, num_of_components, 'vip')['ropls_oplsda@vipVn']
     modeldf = oplsda(measurements, groups, num_of_components, 'modeldf')
     summarydf = oplsda(measurements, groups, num_of_components, 'summarydf')
 
@@ -848,9 +857,11 @@ def get_oplsda(validated_table: ValidatedMetaboliteTable,
 
         sdev.append(sqrt(r2[i]))
 
-    formatted_scores = {'x': x, 'sdev': sdev}
-    formatted_vip = vip['ropls_oplsda@vipVn']
+    formatted_vip_scores = [
+        {'col': column_names[i], 'vip': vip} for i, vip in enumerate(vip_scores)
+    ]
 
+    formatted_scores = {'x': x, 'sdev': sdev}
     labels = validated_table.sample_metadata
     labels = clean(pandas.concat([groups, labels], axis=1)).to_dict('list')
     rows = measurements.index.tolist()
@@ -858,7 +869,7 @@ def get_oplsda(validated_table: ValidatedMetaboliteTable,
     return jsonify({
         'scores': formatted_scores,
         'loadings': formatted_loadings,
-        'vip': formatted_vip,
+        'vip_scores': formatted_vip_scores,
         'labels': labels,
         'rows': rows,
         'r2': r2,

--- a/web/src/components/vis/OplsdaPage/OplsdaPage.vue
+++ b/web/src/components/vis/OplsdaPage/OplsdaPage.vue
@@ -31,8 +31,8 @@ export default defineComponent({
       numComponentsVal: '3',
       pcY: 2,
       numComponents: 3,
-      group1: dataset.value?.groupLevels[0]?.name || '',
-      group2: dataset.value?.groupLevels[1]?.name || '',
+      group1: dataset.value?.groupLevels[0]?.name || null,
+      group2: dataset.value?.groupLevels[1]?.name || null,
       showEllipses: true,
       showCrosshairs: true,
       showCutoffs: true,
@@ -71,7 +71,7 @@ export default defineComponent({
     const eigenvalues = computed(() => plot.value.data?.scores.sdev || []);
     const rowLabels = computed(() => plot.value.data?.rows || []);
     const groupLabels = computed(() => plot.value.data?.labels || {});
-    const columns = computed(() => dataset.value?.column.data || []);
+    const columns = computed(() => dataset.value?.column?.data || []);
     const groupLevels = computed(() => dataset.value?.groupLevels || []);
     const groupNames = computed(() => groupLevels.value.map(
       (level: { name: string }) => level.name,
@@ -104,7 +104,8 @@ export default defineComponent({
         controls.group2 = oldGroup;
         changePlotArgs({ group2: oldGroup });
       }
-      if (plot.value) {
+      // only force a refresh if both groups are set
+      if (plot.value && controls.group1 && controls.group2) {
         plot.value.valid = false;
       }
     });
@@ -115,16 +116,10 @@ export default defineComponent({
         controls.group1 = oldGroup;
         changePlotArgs({ group1: oldGroup });
       }
-      if (plot.value) {
+      // only force a refresh if both groups are set
+      if (plot.value && controls.group1 && controls.group2) {
         plot.value.valid = false;
       }
-    });
-
-    // If no groups are selected after the plot loads, select the first two groups
-    watch(() => dataset.value, () => {
-      controls.group1 = dataset.value?.groupLevels[0]?.name || '';
-      controls.group2 = dataset.value?.groupLevels[1]?.name || '';
-      changePlotArgs({ group1: controls.group1, group2: controls.group2 });
     });
 
     return {

--- a/web/src/components/vis/OplsdaPage/VipPlot.vue
+++ b/web/src/components/vis/OplsdaPage/VipPlot.vue
@@ -1,0 +1,27 @@
+<script lang="ts">
+import VipPlot from '@/components/vis/VipPlot.vue';
+import VisTile from '@/components/vis/VisTile.vue';
+import { defineComponent } from '@vue/composition-api';
+
+export default defineComponent({
+  components: {
+    VipPlot,
+    VisTile,
+  },
+  props: {
+    vipScores: {
+      type: Array,
+      required: true,
+    },
+  },
+});
+</script>
+
+<template>
+  <vis-tile
+    title="OPLS-DA VIP Plot"
+    svg-download
+  >
+    <vip-plot :vip-scores="vipScores" />
+  </vis-tile>
+</template>

--- a/web/src/components/vis/PlsdaPage/VipPlot.vue
+++ b/web/src/components/vis/PlsdaPage/VipPlot.vue
@@ -1,0 +1,27 @@
+<script lang="ts">
+import VipPlot from '@/components/vis/VipPlot.vue';
+import VisTile from '@/components/vis/VisTile.vue';
+import { defineComponent } from '@vue/composition-api';
+
+export default defineComponent({
+  components: {
+    VipPlot,
+    VisTile,
+  },
+  props: {
+    vipScores: {
+      type: Array,
+      required: true,
+    },
+  },
+});
+</script>
+
+<template>
+  <vis-tile
+    title="PLS-DA VIP Plot"
+    svg-download
+  >
+    <vip-plot :vip-scores="vipScores" />
+  </vis-tile>
+</template>

--- a/web/src/components/vis/VipPlot.vue
+++ b/web/src/components/vis/VipPlot.vue
@@ -1,0 +1,215 @@
+<script lang="ts">
+import {
+  PropType, defineComponent, computed, ref, watchEffect, onMounted, Ref,
+} from '@vue/composition-api';
+import { axisBottom, axisLeft } from 'd3-axis';
+import { scaleBand, scaleLinear } from 'd3-scale';
+import { select, event } from 'd3-selection';
+import 'd3-transition';
+
+import useAxisPlot from './use/useAxisPlot';
+
+const margin = {
+  top: 20, right: 20, bottom: 100, left: 50,
+};
+const fadeInDuration = 500;
+const duration = 200;
+const maxLabelLength = 15;
+
+interface VipValue {
+  col: string;
+  vip: number;
+}
+
+export default defineComponent({
+  props: {
+    vipScores: {
+      required: true,
+      type: Array as PropType<VipValue[]>,
+    },
+    sortVip: {
+      type: Boolean,
+      required: false,
+      default: false,
+    },
+  },
+
+  setup(props) {
+    const svgRef = ref() as Ref<HTMLElement>;
+    const mainRef = ref() as Ref<HTMLElement>;
+    const tooltipRef = ref() as Ref<HTMLElement>;
+    const width = ref(400);
+    const height = ref(400);
+
+    const {
+      dwidth,
+      dheight,
+      setXLabel,
+      setYLabel,
+      axisPlot,
+    } = useAxisPlot({ margin, width, height });
+
+    const labels = computed(() => props.vipScores.map((v) => v.col));
+    const vipScores = computed(() => props.vipScores.map((v) => v.vip));
+
+    const scaleX = computed(() => scaleBand<string>()
+      .domain(labels.value)
+      .range([0, dwidth.value])
+      .padding(0.4));
+    const yRange = computed(() => [0.0, Math.max(...vipScores.value) * 1.1]);
+    const scaleY = computed(() => scaleLinear()
+      .domain(yRange.value)
+      .range([dheight.value, 0]));
+
+    const axisX = computed(() => axisBottom(scaleX.value)
+      .tickFormat((tick) => {
+        if (tick.length > maxLabelLength) {
+          return `${tick.substring(0, maxLabelLength - 3)}...`;
+        }
+        return tick;
+      }));
+    const axisY = computed(() => axisLeft(scaleY.value));
+
+    onMounted(() => {
+      watchEffect(() => {
+        // Recalculate width/height
+        const bb = mainRef.value.getBoundingClientRect();
+        height.value = bb.height;
+        width.value = bb.width;
+
+        // Set up plot
+        const svg = select(svgRef.value);
+        const tooltip = select(tooltipRef.value);
+        axisPlot(svg, axisX.value, axisY.value);
+        setXLabel(svg, 'Component');
+        setYLabel(svg, 'VIP Score');
+
+        // @ts-ignore d3 typings are bad
+        svg.select('g.bars')
+          .selectAll('rect')
+          .data(props.vipScores)
+          // @ts-ignore d3 typings are bad
+          .join((enter) => enter.append('rect')
+            .attr('x', (d) => scaleX.value(d.col))
+            .attr('y', (d) => scaleY.value(d.vip))
+            .attr('width', scaleX.value.bandwidth())
+            .attr('height', (d) => dheight.value - scaleY.value(d.vip))
+            .style('fill', 'black')
+            .style('fill-opacity', 1.0)
+            .on('mouseover', (d) => {
+              tooltip.transition()
+                .duration(duration)
+                .style('opacity', 0.9);
+              tooltip.html(`<b>${d.col}</b><br>${d.vip}`)
+                .style('left', `${event.clientX + 15}px`)
+                .style('top', `${event.pageY - 30}px`);
+            })
+            .on('mouseout', () => {
+              tooltip.transition()
+                .duration(duration)
+                .style('opacity', 0.0);
+            }))
+          .transition()
+          .duration(fadeInDuration)
+          .attr('x', (d) => scaleX.value(d.col))
+          .attr('y', (d) => scaleY.value(d.vip))
+          .attr('width', scaleX.value.bandwidth())
+          .attr('height', (d) => dheight.value - scaleY.value(d.vip));
+
+        svg.select('g.label.x')
+          .selectAll('text')
+          .attr('dy', 30);
+        svg.select('g.x-axis')
+          .selectAll('text')
+          .attr('dx', -40)
+          .attr('dy', -7)
+          .attr('transform', 'rotate(-90)')
+          .on('mouseover', (d) => {
+            tooltip.transition()
+              .duration(duration)
+              .style('opacity', 0.9);
+            tooltip.html(`<b>${d}</b>`)
+              .style('left', `${event.clientX + 15}px`)
+              .style('top', `${event.pageY - 30}px`);
+          })
+          .on('mouseout', () => {
+            tooltip.transition()
+              .duration(duration)
+              .style('opacity', 0.0);
+          });
+      });
+    });
+
+    return {
+      svgRef,
+      mainRef,
+      tooltipRef,
+      width,
+      height,
+    };
+  },
+});
+</script>
+
+<template>
+  <div
+    ref="mainRef"
+    class="main"
+  >
+    <svg
+      ref="svgRef"
+      :width="width"
+      :height="height"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <g class="master">
+        <g class="axes">
+          <g class="label x">
+            <text />
+          </g>
+          <g class="label y">
+            <text />
+          </g>
+        </g>
+        <g class="plot">
+          <g class="bars" />
+        </g>
+      </g>
+    </svg>
+    <div
+      ref="tooltipRef"
+      class="tooltip"
+    />
+  </div>
+</template>
+
+<style scoped>
+div.tooltip {
+  position: fixed;
+  text-align: center;
+  padding: 2px;
+  background: #eee;
+  border: 0px;
+  border-radius: 3px;
+  pointer-events: none;
+  z-index: 20;
+  opacity: 0;
+}
+
+path.line {
+  fill: none;
+  stroke: black;
+}
+
+line.cutoff50 {
+  stroke: gray;
+}
+
+line.cutoff80 {
+  stroke: firebrick;
+}
+
+line.cutoff90 {
+  stroke: red;
+}
+</style>

--- a/web/src/components/vis/VipPlot.vue
+++ b/web/src/components/vis/VipPlot.vue
@@ -113,7 +113,6 @@ export default defineComponent({
           .duration(fadeInDuration)
           .attr('x', (d) => scaleX.value(d.col))
           .attr('y', (d) => scaleY.value(d.vip))
-          .attr('width', scaleX.value.bandwidth())
           .attr('height', (d) => dheight.value - scaleY.value(d.vip));
 
         svg.select('g.label.x')


### PR DESCRIPTION
* Add `VipPlot.vue`
* Add VipPlot to OPLSDA and PLSDA pages
  * PLSDA page has a complete set of VIP scores for each "numComponent", so there is also a selector to choose which component to render
  * Both have a toggle to sort based on component name or on VIP score