### PR TITLE
Create .env

### DIFF
--- a/devops/docker/.env
+++ b/devops/docker/.env
@@ -1,0 +1,1 @@
+COMPOSE_PROJECT_NAME=viime


### PR DESCRIPTION
Without this, the docker-compose project stack spins up as `docker_<containername>` because of the parent file name, and it's really hard to figure out what stack this is when I have 6 running.  since `docker/` is a common convention, resources like volumes and networks name-collide, which is a pain.