### PR TITLE
Track ellipses based on category names

### DIFF
--- a/web/src/components/vis/ScorePlot.vue
+++ b/web/src/components/vis/ScorePlot.vue
@@ -523,7 +523,7 @@ export default {
       select(this.$refs.chart)
         .select('.c3-custom-ellipses')
         .selectAll('ellipse')
-        .data(confidenceEllipses)
+        .data(confidenceEllipses, (d) => d.category)
         .join(
           (enter) => enter
             .append('ellipse')


### PR DESCRIPTION
This allows for the ellipse colors to match up with the current colormap. It also allows ellipses to be destroyed/created when the category names change (as they often do in real datasets).

Fixes #672