### PR TITLE
Bump package version numbers to 1.0.1

### DIFF
--- a/e2e-test/package.json
+++ b/e2e-test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "test",
-  "version": "0.1.0",
+  "version": "1.0.1",
   "private": true,
   "scripts": {
     "lint": "eslint .",

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ data_files.extend(list_files_recursive('static'))
 
 setup(
     name='viime',
-    version='0.1.0',
+    version='1.0.1',
     author='Kitware, Inc.',
     author_email='kitware@kitware.com',
     packages=find_packages(include=['viime']),

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "viime",
-  "version": "0.1.0",
+  "version": "1.0.1",
   "private": true,
   "scripts": {
     "serve": "vue-cli-service serve",


### PR DESCRIPTION
The JOSS reviewers found that I had forgotten to bump the version strings to `1.0.0` in the bundle I created for submission / archiving on Zenodo. This rectifies that mistake. It will also be followed by another GitHub release and an update of the files in the Zenodo archive.