### PR TITLE
Group analyses

### DIFF
--- a/web/src/components/vis/GroupPredictionTile.vue
+++ b/web/src/components/vis/GroupPredictionTile.vue
@@ -43,7 +43,7 @@ export default defineComponent({
       analysisOptions: [
         { value: 'all', text: 'All metabolites' },
         { value: 'selected', text: 'Selected Metabolites' },
-        { value: 'factor', text: 'Factor Analysis' }
+        { value: 'factor', text: 'Factor Analysis' },
       ],
       method: 'random_forest',
       methodOptions: [
@@ -84,9 +84,7 @@ export default defineComponent({
     });
     // The "All" and "Selected" analysis options do not do any analysis,
     // so we don't want to show the Metabolite Source selector
-    const showMetaboliteSource = computed(() => {
-      return controls.analysis !== 'all' && controls.analysis !== 'selected';
-    });
+    const showMetaboliteSource = computed(() => controls.analysis !== 'all' && controls.analysis !== 'selected');
     const sensitivities = computed(() => {
       if (!plot.value.data
         || !controls.group1
@@ -154,7 +152,7 @@ export default defineComponent({
       controls.metabolites = newSource === 'all' ? [] : columns.value;
       changePlotArgs({ columns: JSON.stringify(controls.metabolites) });
     });
-    watch(() => controls.metaboliteSource, (newSource) => {
+    watch(() => controls.metaboliteSource, () => {
       controls.metabolites = columns.value;
       changePlotArgs({ columns: JSON.stringify(controls.metabolites) });
     });

--- a/web/src/components/vis/GroupPredictionTile.vue
+++ b/web/src/components/vis/GroupPredictionTile.vue
@@ -1,6 +1,6 @@
 <script lang="ts">
 import {
-  defineComponent, computed, ref, toRef, watch, onMounted, Ref, reactive,
+  defineComponent, computed, ref, toRef, watch, Ref, reactive,
 } from '@vue/composition-api';
 import RocCurve from './RocCurve.vue';
 import VisTileLarge from './VisTileLarge.vue';
@@ -30,8 +30,6 @@ export default defineComponent({
     VisTileLarge,
     RocCurve,
   },
-
-  // mixins: [plotData('roc')],
 
   setup(props) {
     const controls = reactive({
@@ -70,9 +68,12 @@ export default defineComponent({
       if (!pcaData.value?.metabolites) {
         return [];
       }
-      const { metabolites } = pcaData.value;
-      // @ts-ignore
-      return metabolites.filter((m, i) => (pcaData.value.factor[i] === controls.metaboliteSource));
+      const pcaDataValue = pcaData.value;
+      if (!pcaDataValue?.metabolites) {
+        return [];
+      }
+      const { metabolites } = pcaDataValue;
+      return metabolites.filter((m, i) => (pcaDataValue.factor[i] === controls.metaboliteSource));
     });
     const groups = computed(() => dataset.value.groupLevels.map((level: Level) => level.name));
     const metaboliteSourceOptions = computed(() => {
@@ -134,10 +135,8 @@ export default defineComponent({
       }
     }
 
-    // Perform an initial factor analysis when component is mounted
-    onMounted(() => {
-      getFactors();
-    });
+    // Perform an initial factor analysis
+    getFactors();
 
     // get new factor analysis when threshold changes
     watch(threshold, () => {
@@ -188,7 +187,6 @@ export default defineComponent({
       specificities,
       auc,
       removeMetabolite,
-      getFactors,
     };
   },
 });

--- a/web/src/components/vis/GroupPredictionTile.vue
+++ b/web/src/components/vis/GroupPredictionTile.vue
@@ -126,44 +126,44 @@ export default defineComponent({
       } catch (err) {
         pcaData.value = null;
       }
-
-      // Perform an initial factor analysis when component is mounted
-      onMounted(() => {
-        getFactors();
-      });
-
-      // get new factor analysis when threshold changes
-      watch(threshold, () => {
-        getFactors();
-        controls.metaboliteSource = 'all';
-      });
-
-      // Clear metabolites when metabolite source is changed to 'All'
-      // If the source is changed to 'Selected' or one of the PC factors,
-      // populate the list with the filtered metabolite and graph them.
-      watch(() => controls.metaboliteSource, (newSource) => {
-        controls.metabolites = newSource === 'all' ? [] : columns.value;
-        changePlotArgs({ columns: JSON.stringify(controls.metabolites) });
-      });
-      watch(() => controls.metabolites, () => {
-        changePlotArgs({ columns: JSON.stringify(controls.metabolites) });
-      });
-      // These two watchers prevent the same group from being selected twice.
-      watch(() => controls.group1, (newGroup, oldGroup) => {
-        changePlotArgs({ group1: newGroup });
-        if (controls.group2 === newGroup) {
-          controls.group2 = oldGroup;
-          changePlotArgs({ group2: oldGroup });
-        }
-      });
-      watch(() => controls.group2, (newGroup, oldGroup) => {
-        changePlotArgs({ group2: newGroup });
-        if (controls.group1 === newGroup) {
-          controls.group1 = oldGroup;
-          changePlotArgs({ group1: oldGroup });
-        }
-      });
     }
+
+    // Perform an initial factor analysis when component is mounted
+    onMounted(() => {
+      getFactors();
+    });
+
+    // get new factor analysis when threshold changes
+    watch(threshold, () => {
+      getFactors();
+      controls.metaboliteSource = 'all';
+    });
+
+    // Clear metabolites when metabolite source is changed to 'All'
+    // If the source is changed to 'Selected' or one of the PC factors,
+    // populate the list with the filtered metabolite and graph them.
+    watch(() => controls.metaboliteSource, (newSource) => {
+      controls.metabolites = newSource === 'all' ? [] : columns.value;
+      changePlotArgs({ columns: JSON.stringify(controls.metabolites) });
+    });
+    watch(() => controls.metabolites, () => {
+      changePlotArgs({ columns: JSON.stringify(controls.metabolites) });
+    });
+    // These two watchers prevent the same group from being selected twice.
+    watch(() => controls.group1, (newGroup, oldGroup) => {
+      changePlotArgs({ group1: newGroup });
+      if (controls.group2 === newGroup) {
+        controls.group2 = oldGroup;
+        changePlotArgs({ group2: oldGroup });
+      }
+    });
+    watch(() => controls.group2, (newGroup, oldGroup) => {
+      changePlotArgs({ group2: newGroup });
+      if (controls.group1 === newGroup) {
+        controls.group1 = oldGroup;
+        changePlotArgs({ group1: oldGroup });
+      }
+    });
     return {
       controls,
       pcaData,

--- a/web/src/components/vis/use/usePlotData.ts
+++ b/web/src/components/vis/use/usePlotData.ts
@@ -15,7 +15,7 @@ export default function usePlotData(id: Ref<string>, plotName: string) {
     store.commit(SET_PLOT, {
       dataset_id: id.value,
       name: plotName,
-      obj: { args: { ...plot.value.args, ...args } },
+      obj: { loading: false, valid: false, args: { ...plot.value.args, ...args } },
     });
   }
 


### PR DESCRIPTION
There is now an Analysis selector where you can choose one of:
* All Metabolites
* Selected Metabolites
* Factor Analysis

The Metabolite Source selector now only appears when Factor Analysis is
selected, and will only contain the PCs.

Also, when `usePlotData` was converted from the `plotData` mixin, I missed a spot
where it invalidated the plot whenever the arguments changed. This means
that new TS plots were not triggering refreshes whenever they should
have. That is now fixed in `usePlotData`.