### PR TITLE
Use proper noun capitalization for "Viime"

### DIFF
--- a/web/src/components/Landing.vue
+++ b/web/src/components/Landing.vue
@@ -219,10 +219,10 @@ v-app.viime-landing
         v-flex(md8, xs12)
           h2.mb-3.pa-0 Ready for Collaboration
           p
-            | The code for VIIME is in a permissive open source library, meaning it can be used and
+            | The code for Viime is in a permissive open source library, meaning it can be used and
             | extended across academia and industry with no restrictions. This includes deploying
-            | VIIME at your institution for your internal research team. If you'd like to partner
-            | with us to deploy or extend VIIME
+            | Viime at your institution for your internal research team. If you'd like to partner
+            | with us to deploy or extend Viime
         v-flex.contacts(md4, xs12)
           div
             feedback-button(front)


### PR DESCRIPTION
We should treat "Viime" as a name rather than an initialism. This PR changes the all-caps usage to proper noun capitalization in all but two instances--I've left it all-caps in the title property, and in the first heading, where the emphasis feels appropriate.