### PR TITLE
Fix SVG downloads not triggering

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(
         'sqlalchemy-utils',
         'webargs >=5.5.3, <6',
         'Werkzeug>=0.15',
-        'xlrd>= 1.0.0'
+        'openpyxl'
     ],
     extras_require={
         'memcached': ['pylibmc'],

--- a/viime/views.py
+++ b/viime/views.py
@@ -95,7 +95,11 @@ def upload_csv_file(file: FileStorage, meta: Dict[str, Any]):
     'meta': JSONDictStr(missing={})
 })
 def upload_excel_file(file: FileStorage, meta: Dict[str, Any]):
-    excel_sheets: Dict[str, pandas.DataFrame] = pandas.read_excel(file, sheet_name=None)
+    excel_sheets: Dict[str, pandas.DataFrame] = pandas.read_excel(
+        file,
+        sheet_name=None,
+        engine='openpyxl',
+    )
     excel_sheets = {sheet: data for (sheet, data) in excel_sheets.items() if not data.empty}
 
     basename = PurePath(cast(str, file.filename)).with_suffix('')

--- a/web/src/components/vis/VisTileLarge.vue
+++ b/web/src/components/vis/VisTileLarge.vue
@@ -52,6 +52,7 @@ export default defineComponent({
       }
     }
     return {
+      el,
       hasControls,
       helpText,
       downloadImage,


### PR DESCRIPTION
`el` is a template ref that allows the `VisTileLarge` component's TypeScript to interact directly with the mounted DOM element. Both the `ref="el"` on the template and the `const el = ref(...);` were set up correctly, but the ref `el` was not returned from the `setup` function, so Vue did not know to autowire that ref when the template was mounted. The download was searching for an `<svg>` element inside the placeholder value of the ref (an empty div), and when it could not find an SVG, it simply did nothing.

The solution is return `el` from the setup function.

Fixes #703 